### PR TITLE
konflux: add labels for enterprise contracts

### DIFF
--- a/Dockerfile.cma-operator
+++ b/Dockerfile.cma-operator
@@ -64,13 +64,42 @@ COPY --from=builder /src/must-gather/collection-scripts/* /usr/bin/
 COPY --from=cli /usr/bin/oc /usr/bin
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
-# TODO(jkyros): This seems weird, why do we do this? 
+# TODO(jkyros): This seems weird, why do we do this?
 RUN mkdir -p /src/cma-operator/app && \
-    ln -s /resources /src/cma-operator/app/resources 
+    ln -s /resources /src/cma-operator/app/resources
+
+# Need the license to pass enterprise pre-flight
+RUN mkdir /licenses
+COPY --from=builder /src/LICENSE /licenses/
 
 #TODO(jkyros): I've goofed somewhere, it's looking here instead and not finding it, but why
 RUN ln -s /resources /src/resources
 USER nobody
+
+# Need to specify a user to pass enterprise pre-flight
+USER nobody
+
+LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler Operator" \
+      io.k8s.description="This is a component of OpenShift which manages Custom Metrics Autoscaler." \
+      com.redhat.component="custom-metrics-autoscaler-operator-container" \
+      name="custom-metrics-autoscaler-operator-rhel-9" \
+      summary="custom-metrics-autoscaler-operator" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler-operator" \
+      description="custom-metrics-autoscaler-operator-container" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+# TODO(jkyros): I don't know what to do about the upstream labels yet, I don't think Konflux gets it for you
+# LABEL upstream-version="${CI_KEDACORE_KEDA_UPSTREAM_VERSION}" \
+#      upstream-vcs-ref="${CI_KEDACORE_KEDA_UPSTREAM_COMMIT}" \
+#      upstream-vcs-type="git" \
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.17"
+
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+LABEL version="2.14.1"
+LABEL release=""
 
 CMD ["/usr/bin/manager"]
 

--- a/Dockerfile.cma-operator-bundle
+++ b/Dockerfile.cma-operator-bundle
@@ -3,7 +3,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder-runner
 
-#TODO(jkyros): Entitlements are still wacky, so we have to disable the entitled channels here, too 
+#TODO(jkyros): Entitlements are still wacky, so we have to disable the entitled channels here, too
 RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms install -y skopeo jq python3 python3-pip
 RUN pip3 install --upgrade pip && pip3 install ruamel.yaml==0.17.9
 
@@ -12,31 +12,20 @@ FROM builder-runner as builder
 
 COPY bundle-hack .
 
-# We're going to copy all the keda bundles in 
-COPY custom-metrics-autoscaler-operator/keda /custom-metrics-autoscaler-operator/keda 
+# We're going to copy all the keda bundles in
+COPY custom-metrics-autoscaler-operator/keda /custom-metrics-autoscaler-operator/keda
 
-# This is going to sort out the most recent one and put it in /manifests/ and /metadata/ so 
-# the next stage can use it from there 
-RUN ./update_bundle.sh 
+# This is going to sort out the most recent one and put it in /manifests/ and /metadata/ so
+# the next stage can use it from there
+RUN ./update_bundle.sh
 
 RUN rm /manifests/keda.*.clusterserviceversion.yaml
 
-#TODO(jkyros): our cma annotations have been wrong since forever, apparently, we should fix that :) 
-# the opm template renderer uses these actually and will do really weird stuff if the package doesn't match 
+#TODO(jkyros): our cma annotations have been wrong since forever, apparently, we should fix that :)
+# the opm template renderer uses these actually and will do really weird stuff if the package doesn't match
 RUN sed -i -e 's#operators.operatorframework.io.bundle.package.v1:.*#operators.operatorframework.io.bundle.package.v1: openshift-custom-metrics-autoscaler-operator#g' metadata/annotations.yaml
 
 FROM ubi9
-
-# Core bundle labels.
-LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
-LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
-LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=custom-metrics-autoscaler-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=stable,3.15
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 # Labels for testing.
 #LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
@@ -46,3 +35,32 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 COPY --from=builder /manifests /manifests/
 COPY --from=builder /metadata /metadata/
 #COPY gatekeeper-operator/bundle/tests/scorecard /tests/scorecard/
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=custom-metrics-autoscaler-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# These labels are necessary for satisfying the enterprise contract
+LABEL com.redhat.component="custom-metrics-autoscaler-operator-bundle-container" \
+      name="custom-metrics-autoscaler-operator-metadata-rhel-9" \
+      summary="Custom Metrics Autoscaler for OpenShift bundle image" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler-operator" \
+      io.k8s.display-name="openshift-custom-metrics-autoscaler-operator" \
+      maintainer="AOS workloads team, <aos-workloads@redhat.com>" \
+      description="Custom Metrics Autoscaler for OpenShift bundle image" \
+      com.redhat.delivery.operator.bundle=true
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.17"
+
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+LABEL version="2.14.1"
+LABEL release=""

--- a/Dockerfile.keda-adapter
+++ b/Dockerfile.keda-adapter
@@ -24,9 +24,9 @@ ENV ARCH=${TARGETARCH}
 # cert errors because it's looking at rhsm-host and not rhsm and won't find the cert
 RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
 
-# TODO(jkyros): pin this to cache when we are able 
-# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but 
-# the channels do not match the targetarch names, so we have to translate before we entble it 
+# TODO(jkyros): pin this to cache when we are able
+# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
+# the channels do not match the targetarch names, so we have to translate before we entble it
 RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
     elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
     fi; \
@@ -53,8 +53,8 @@ FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 WORKDIR /
 # TODO(jkyros): It will try to pull from the RHEL channels because of the entitlement secret, so we have to disable
-# all the repos (the RHEL ones) and then enable the ubi repos. 
-RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms reinstall -y tzdata 
+# all the repos (the RHEL ones) and then enable the ubi repos.
+RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms reinstall -y tzdata
 COPY --from=builder /src/bin/keda-adapter /usr/bin/
 RUN ln -s /usr/bin/keda-adapter /keda-adapter
 
@@ -63,5 +63,28 @@ RUN mkdir /licenses
 COPY --from=builder /src/LICENSE /licenses/
 
 USER nobody
+
+LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler Adapter" \
+      io.k8s.description="This is a component of OpenShift which provides a custom metrics API endpoint for pod autoscaling." \
+      com.redhat.component="custom-metrics-autoscaler-adapter-container" \
+      name="custom-metrics-autoscaler-adapter-rhel-9" \
+      summary="custom-metrics-autoscaler-adapter" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler-adapter" \
+      description="custom-metrics-autoscaler-container-adapter" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+# TODO(jkyros): I don't know what to do about the upstream labels yet, I don't think Konflux gets it for you
+#LABEL upstream-version="${CI_KEDACORE_KEDA_UPSTREAM_VERSION}" \
+#      upstream-vcs-ref="${CI_KEDACORE_KEDA_UPSTREAM_COMMIT}" \
+#      upstream-vcs-type="git" \
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.17"
+
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+LABEL version="2.14.1"
+LABEL release=""
+
 
 ENTRYPOINT ["/usr/bin/keda-adapter", "--secure-port=6443", "--logtostderr=true", "--v=0"]

--- a/Dockerfile.keda-operator
+++ b/Dockerfile.keda-operator
@@ -26,9 +26,9 @@ ENV ARCH=${TARGETARCH}
 # cert errors because it's looking at rhsm-host and not rhsm and won't find the cert
 RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
 
-# TODO(jkyros): pin this to cache when we are able 
-# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but 
-# the channels do not match the targetarch names, so we have to translate before we entble it 
+# TODO(jkyros): pin this to cache when we are able
+# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
+# the channels do not match the targetarch names, so we have to translate before we entble it
 RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
     elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
     fi; \
@@ -55,8 +55,8 @@ FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 WORKDIR /
 # TODO(jkyros): It will try to pull from the RHEL channels because of the entitlement secret, so we have to disable
-# all the repos (the RHEL ones) and then enable the ubi repos. 
-RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms reinstall -y tzdata 
+# all the repos (the RHEL ones) and then enable the ubi repos.
+RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms reinstall -y tzdata
 COPY --from=builder /src/bin/keda /usr/bin/
 RUN ln -s /usr/bin/keda /keda
 
@@ -66,6 +66,28 @@ COPY --from=builder /src/LICENSE /licenses/
 
 USER nobody
 
+# These labels are necessary to pass the enterprise contracts
+LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler" \
+      io.k8s.description="This is a component of OpenShift which provides pod scaling capabilities based upon various metrics sources." \
+      com.redhat.component="custom-metrics-autoscaler-container" \
+      name="custom-metrics-autoscaler-rhel-9" \
+      summary="custom-metrics-autoscaler" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler" \
+      description="custom-metrics-autoscaler-container" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+# TODO(jkyros): I don't know what to do about the upstream labels yet, I don't think Konflux gets it for you
+#LABEL upstream-version="${CI_KEDACORE_KEDA_UPSTREAM_VERSION}" \
+#      upstream-vcs-ref="${CI_KEDACORE_KEDA_UPSTREAM_COMMIT}" \
+#      upstream-vcs-type="git" \
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.17"
+
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+LABEL version="2.14.1"
+LABEL release=""
 
 
 ENTRYPOINT ["/usr/bin/keda", "--zap-log-level=info", "--zap-encoder=console"]

--- a/Dockerfile.keda-webhooks
+++ b/Dockerfile.keda-webhooks
@@ -24,9 +24,9 @@ ENV ARCH=${TARGETARCH}
 # cert errors because it's looking at rhsm-host and not rhsm and won't find the cert
 RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
 
-# TODO(jkyros): pin this to cache when we are able 
-# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but 
-# the channels do not match the targetarch names, so we have to translate before we entble it 
+# TODO(jkyros): pin this to cache when we are able
+# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
+# the channels do not match the targetarch names, so we have to translate before we entble it
 RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
     elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
     fi; \
@@ -53,8 +53,8 @@ FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 WORKDIR /
 # TODO(jkyros): It will try to pull from the RHEL channels because of the entitlement secret, so we have to disable
-# all the repos (the RHEL ones) and then enable the ubi repos. 
-RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms reinstall -y tzdata 
+# all the repos (the RHEL ones) and then enable the ubi repos.
+RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms reinstall -y tzdata
 COPY --from=builder /src/bin/keda-admission-webhooks /usr/bin/
 RUN ln -s /usr/bin/keda-admission-webhooks /keda-admission-webhooks
 
@@ -64,6 +64,29 @@ COPY --from=builder /src/LICENSE /licenses/
 
 USER nobody
 
+
+# These labels are necessary to pass the enterprise contracts
+LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler Admission Webhooks" \
+      io.k8s.description="This is a component of OpenShift which validates KEDA objects." \
+      com.redhat.component="custom-metrics-autoscaler-admission-webhooks-container" \
+      name="custom-metrics-autoscaler-admission-webhooks-rhel-9" \
+      summary="custom-metrics-autoscaler-admission-webhooks" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler-admission-webhooks" \
+      description="custom-metrics-autoscaler-container-admission-webhooks" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+# TODO(jkyros): I don't know what to do about the upstream labels yet, I don't think Konflux gets it for you
+#LABEL upstream-version="${CI_KEDACORE_KEDA_UPSTREAM_VERSION}" \
+#      upstream-vcs-ref="${CI_KEDACORE_KEDA_UPSTREAM_COMMIT}" \
+#      upstream-vcs-type="git" \
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.17"
+
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+LABEL version="2.14.1"
+LABEL release=""
 
 
 ENTRYPOINT ["/usr/bin/keda-admission-webhooks", "--zap-log-level=info", "--zap-encoder=console"]


### PR DESCRIPTION
We were missing some medatada that was making our enterprise contract test fail, this should supply it. 