### PR TITLE
Enable hermetic and prefetch for operands

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -72,11 +72,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": "."}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": "."}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -73,11 +73,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/go.mod"}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/go.mod"}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -73,11 +73,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/go.mod"}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/go.mod"}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -72,11 +72,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/go.mod"}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/go.mod"}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string


### PR DESCRIPTION
This will probably fail because we don't have RPMs yet, but it should prefetch the go deps 