### PR TITLE
Try to inject the entitlement ca bundle to cachi2

### DIFF
--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/",  "options": { "ssl": { "ssl_verify": 0 } } }'
+    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/"}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
@@ -177,6 +177,10 @@ spec:
         value: $(params.image-expires-after)
       - name: dev-package-managers
         value: "true"
+      - name: caTrustConfigMapName
+        value: "prefetch-entitled-ca-bundle"
+      - name: caTrustConfigMapKey
+        value: "redhat-uep.pem"
       runAfter:
       - clone-repository
       taskRef:


### PR DESCRIPTION
Alright, well that didn't work, it won't let you specify additional args (like SSL) which is probably good, and makes sense. So we're going to try to inject the bundle and see if it mounts it. The args to the pipeline stage say it can. We'll see :smile: 