### PR TITLE
PODAUTO-239: Update labels for enterprise contract, let pipelnes trigger when they themselves change 

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# TODO(jkyros): I think it's reading the nested .snyk files from the modules, otherwise it would have
+# flagged all our tests. Some of our tools are written in c/c++ and are a mess, but we don't ship them, we
+# just build with them, so exclude them for now. 
+exclude:
+  global:
+    - "tools/**"

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux" && ( "bundle-hack/update_bundle.sh".pathChanged()  || "Dockerfile.cma-operator-bundle".pathChanged() || "bundle-hack/imagerefs/keda-operator.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-webhooks.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-adapter.pullspec".pathChanged() )
+      == "cma-konflux" && ( "bundle-hack/update_bundle.sh".pathChanged()  || "Dockerfile.cma-operator-bundle".pathChanged() || "bundle-hack/imagerefs/keda-operator.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-webhooks.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-adapter.pullspec".pathChanged() || ".tekton/custom-metrics-autoscaler-bundle-pull-request.yaml".pathChanged()  )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/custom-metrics-autoscaler-operator-bundle.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "bundle-hack/update_bundle.sh".pathChanged()  || "Dockerfile.cma-operator-bundle".pathChanged() || "bundle-hack/imagerefs/keda-operator.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-webhooks.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-adapter.pullspec".pathChanged() || "bundle-hack/imagerefs/custom-metrics-autoscaler-operator.pullspec".pathChanged() )
+      == "cma-konflux" && ( "bundle-hack/update_bundle.sh".pathChanged()  || "Dockerfile.cma-operator-bundle".pathChanged() || "bundle-hack/imagerefs/keda-operator.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-webhooks.pullspec".pathChanged() || "bundle-hack/imagerefs/keda-adapter.pullspec".pathChanged() || "bundle-hack/imagerefs/custom-metrics-autoscaler-operator.pullspec".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-bundle-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -72,7 +72,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() )
+      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -76,7 +76,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -76,7 +76,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".", "type":"rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/custom-metrics-autoscaler-operator.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() )
+      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -70,7 +70,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".", "type": "rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod","path": "custom-metrics-autoscaler-operator/"},{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod","path": "custom-metrics-autoscaler-operator/"},{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux"  && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() )
+      == "cma-konflux"  && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   creationTimestamp: null
   labels:

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -77,7 +77,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -73,7 +73,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -77,7 +77,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/keda-adapter.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() )
+      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -70,7 +70,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux"  && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() )
+      == "cma-konflux"  && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-pull-request.yaml".pathChanged())
   creationTimestamp: null
   creationTimestamp: null
   labels:

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -77,7 +77,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -73,7 +73,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -77,7 +77,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/keda-operator.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() )
+      == "cma-konflux" && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -70,7 +70,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -72,7 +72,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -76,7 +76,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux" && ("kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() )
+      == "cma-konflux" && ("kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -76,7 +76,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"type": "gomod", "path": ".","type": "gomod", "path": "kedacore-keda/hack/tooldeps/","type": "rpm","path":"rpm-lockfiles/"}'
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/keda-webhooks.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() )
+      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -70,7 +70,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -74,7 +74,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"}]'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/Dockerfile.cma-operator
+++ b/Dockerfile.cma-operator
@@ -99,7 +99,9 @@ LABEL com.redhat.openshift.versions="v4.17"
 
 # Chore: this will get used in the release policy, so update this when our version we're releasing changes
 LABEL version="2.14.1"
-LABEL release=""
+# I don't know that we can auto-increment this without an additional pipeline stage or something, but if we omit it,
+# we fail the metadata requirements, so we have to put _something_ here
+LABEL release="1"
 
 CMD ["/usr/bin/manager"]
 

--- a/Dockerfile.cma-operator-bundle
+++ b/Dockerfile.cma-operator-bundle
@@ -63,4 +63,12 @@ LABEL com.redhat.openshift.versions="v4.17"
 
 # Chore: this will get used in the release policy, so update this when our version we're releasing changes
 LABEL version="2.14.1"
-LABEL release=""
+# I don't know that we can auto-increment this without an additional pipeline stage or something, but if we omit it,
+# we fail the metadata requirements, so we have to put _something_ here
+LABEL release="1"
+
+# Need the license to pass enterprise pre-flight
+RUN mkdir /licenses
+COPY --from=builder /src/LICENSE /licenses/
+
+USER nobody

--- a/Dockerfile.cma-operator-bundle
+++ b/Dockerfile.cma-operator-bundle
@@ -14,6 +14,7 @@ COPY bundle-hack .
 
 # We're going to copy all the keda bundles in
 COPY custom-metrics-autoscaler-operator/keda /custom-metrics-autoscaler-operator/keda
+COPY custom-metrics-autoscaler-operator/LICENSE /custom-metrics-autoscaler-operator/LICENSE
 
 # This is going to sort out the most recent one and put it in /manifests/ and /metadata/ so
 # the next stage can use it from there
@@ -69,6 +70,6 @@ LABEL release="1"
 
 # Need the license to pass enterprise pre-flight
 RUN mkdir /licenses
-COPY --from=builder /src/LICENSE /licenses/
+COPY --from=builder /custom-metrics-autoscaler-operator/LICENSE /licenses/
 
 USER nobody

--- a/Dockerfile.keda-adapter
+++ b/Dockerfile.keda-adapter
@@ -84,7 +84,9 @@ LABEL com.redhat.openshift.versions="v4.17"
 
 # Chore: this will get used in the release policy, so update this when our version we're releasing changes
 LABEL version="2.14.1"
-LABEL release=""
+# I don't know that we can auto-increment this without an additional pipeline stage or something, but if we omit it,
+# we fail the metadata requirements, so we have to put _something_ here
+LABEL release="1"
 
 
 ENTRYPOINT ["/usr/bin/keda-adapter", "--secure-port=6443", "--logtostderr=true", "--v=0"]

--- a/Dockerfile.keda-adapter
+++ b/Dockerfile.keda-adapter
@@ -27,10 +27,18 @@ RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
 # TODO(jkyros): pin this to cache when we are able
 # protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
 # the channels do not match the targetarch names, so we have to translate before we entble it
+# TODO(jkyros): cachito env will favor activation keys if one is present, you can either use the activation
+# key or etc-pki-entitlement secret, but not both, so that's why I'm using activation keys here, because we have one
 RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
     elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
+    elif [ ${ARCH} == "s390x" ]; then ARCH="s390x"; \
+    elif [ ${ARCH} == "ppc64le" ]; then ARCH="ppc64le"; \
     fi; \
-    dnf install --enablerepo=codeready-builder-for-rhel-9-${ARCH}-rpms -y protobuf-compiler --forcearch ${ARCH}
+    export SMDEV_CONTAINER_OFF=1 && \
+    subscription-manager register --org $(cat "/activation-key/orgid") --activationkey $(cat "/activation-key/activationkey") && \
+    subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH}-rpms && \
+    dnf install -y protobuf-compiler && \
+    subscription-manager unregister
 
 
 # Get the sources in here

--- a/Dockerfile.keda-operator
+++ b/Dockerfile.keda-operator
@@ -29,10 +29,18 @@ RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
 # TODO(jkyros): pin this to cache when we are able
 # protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
 # the channels do not match the targetarch names, so we have to translate before we entble it
+# TODO(jkyros): cachito env will favor activation keys if one is present, you can either use the activation
+# key or etc-pki-entitlement secret, but not both, so that's why I'm using activation keys here, because we have one
 RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
     elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
+    elif [ ${ARCH} == "s390x" ]; then ARCH="s390x"; \
+    elif [ ${ARCH} == "ppc64le" ]; then ARCH="ppc64le"; \
     fi; \
-    dnf install --enablerepo=codeready-builder-for-rhel-9-${ARCH}-rpms -y protobuf-compiler --forcearch ${ARCH}
+    export SMDEV_CONTAINER_OFF=1 && \
+    subscription-manager register --org $(cat "/activation-key/orgid") --activationkey $(cat "/activation-key/activationkey") && \
+    subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH}-rpms && \
+    dnf install -y protobuf-compiler && \
+    subscription-manager unregister
 
 
 # Get the sources in here

--- a/Dockerfile.keda-operator
+++ b/Dockerfile.keda-operator
@@ -87,7 +87,9 @@ LABEL com.redhat.openshift.versions="v4.17"
 
 # Chore: this will get used in the release policy, so update this when our version we're releasing changes
 LABEL version="2.14.1"
-LABEL release=""
+# I don't know that we can auto-increment this without an additional pipeline stage or something, but if we omit it,
+# we fail the metadata requirements, so we have to put _something_ here
+LABEL release="1"
 
 
 ENTRYPOINT ["/usr/bin/keda", "--zap-log-level=info", "--zap-encoder=console"]

--- a/Dockerfile.keda-webhooks
+++ b/Dockerfile.keda-webhooks
@@ -27,13 +27,21 @@ RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
 # TODO(jkyros): pin this to cache when we are able
 # protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
 # the channels do not match the targetarch names, so we have to translate before we entble it
+# TODO(jkyros): cachito env will favor activation keys if one is present, you can either use the activation
+# key or etc-pki-entitlement secret, but not both, so that's why I'm using activation keys here, because we have one
 RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
     elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
+    elif [ ${ARCH} == "s390x" ]; then ARCH="s390x"; \
+    elif [ ${ARCH} == "ppc64le" ]; then ARCH="ppc64le"; \
     fi; \
-    dnf install --enablerepo=codeready-builder-for-rhel-9-${ARCH}-rpms -y protobuf-compiler --forcearch ${ARCH}
+    export SMDEV_CONTAINER_OFF=1 && \
+    subscription-manager register --org $(cat "/activation-key/orgid") --activationkey $(cat "/activation-key/activationkey") && \
+    subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH}-rpms && \
+    dnf install -y protobuf-compiler && \
+    subscription-manager unregister
 
 
-## Get the sources in here
+# Get the sources in here
 COPY /kedacore-keda/ /src/
 
 # And the tools, but separately

--- a/Dockerfile.keda-webhooks
+++ b/Dockerfile.keda-webhooks
@@ -86,8 +86,9 @@ LABEL com.redhat.openshift.versions="v4.17"
 
 # Chore: this will get used in the release policy, so update this when our version we're releasing changes
 LABEL version="2.14.1"
-LABEL release=""
-
+# I don't know that we can auto-increment this without an additional pipeline stage or something, but if we omit it,
+# we fail the metadata requirements, so we have to put _something_ here
+LABEL release="1"
 
 ENTRYPOINT ["/usr/bin/keda-admission-webhooks", "--zap-log-level=info", "--zap-encoder=console"]
 

--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -22,6 +22,11 @@ export KEDA_ADAPTER_PULLSPEC=$(<"imagerefs/keda-adapter.pullspec")
 [[ -z "$KEDA_WEBHOOK_PULLSPEC" ]] && { echo "keda webhook pullspec is empty"; exit 1;}
 [[ -z "$KEDA_ADAPTER_PULLSPEC" ]] && { echo "keda adapter pullspec is empty"; exit 1;}
 
+# TODO(jkyros): we probably need multiple dockerfiles with different targets that feed an arg into this script, e.g. "push to stage", "push to prod", "push to quay"
+CMA_OPERATOR_PULLSPEC=$( echo $CMA_OPERATOR_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.stage.redhat.io/#" )
+KEDA_OPERATOR_PULLSPEC=$( echo $KEDA_OPERATOR_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.stage.redhat.io/#" )
+KEDA_WEBHOOK_PULLSPEC=$( echo $KEDA_WEBHOOK_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.stage.redhat.io/#" )
+KEDA_ADAPTER_PULLSPEC=$( echo $KEDA_ADAPTER_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.stage.redhat.io/#" )
 
 # Since we moved the versioned manifest to /manifests, we can just use it from there
 export CSV_FILE=/manifests/cma.v${VERSION}.clusterserviceversion.yaml


### PR DESCRIPTION
The "release" label wasn't populated, and that upsets the enterprise contract. We'll have to figure out what we want to put in it, but something does have to go there.

Also,  now the on-cel expression didn't include the pipelines themselves, so we weren't getting tests when we changed the pipeline, now we will. 