### PR TITLE
NO-JIRA: Mistake extra chars in webhook dockerfile, need to fix 

### DIFF
--- a/Dockerfile.keda-webhooks
+++ b/Dockerfile.keda-webhooks
@@ -100,4 +100,3 @@ LABEL release="1"
 
 ENTRYPOINT ["/usr/bin/keda-admission-webhooks", "--zap-log-level=info", "--zap-encoder=console"]
 
-gi


### PR DESCRIPTION
I thought I fixed this but I never pushed it. 