### PR TITLE
force a bundle build to resync

### DIFF
--- a/Dockerfile.cma-operator-bundle
+++ b/Dockerfile.cma-operator-bundle
@@ -35,7 +35,6 @@ FROM ubi9
 # Copy files to locations specified by labels.
 COPY --from=builder /manifests /manifests/
 COPY --from=builder /metadata /metadata/
-#COPY gatekeeper-operator/bundle/tests/scorecard /tests/scorecard/
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
This is a dummy cleanup change to retrigger the bundle build. The test run failed, didn't snapshot the image, and now our most recent snapshot has the wrong bundle. Yay! 