### PR TITLE
Revert "konflux: add rpm signing stage to bundle pipeline"

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
@@ -405,27 +405,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-    - name: rpms-signature-scan
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values: ["false"]
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: rpms-signature-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
-        - name: kind
-          value: task
-        resolver: bundles
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: push-dockerfile
       params:
       - name: IMAGE

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
@@ -403,27 +403,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-    - name: rpms-signature-scan
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values: ["false"]
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: rpms-signature-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
-        - name: kind
-          value: task
-        resolver: bundles
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: push-dockerfile
       params:
       - name: IMAGE


### PR DESCRIPTION
This reverts commit 98850dc81211e468344b8a847faa503ce2daf165.

There might have been something wrong with how this got added, let's see if it triggers on revert. 