### PR TITLE
PODAUTO-255: Reference real bundle location in fbc now that we've opted in

### DIFF
--- a/Dockerfile.cma-operator-bundle
+++ b/Dockerfile.cma-operator-bundle
@@ -23,7 +23,7 @@ COPY releaseNum /releaseNum
 
 # This is going to sort out the most recent one and put it in /manifests/ and /metadata/ so
 # the next stage can use it from there
-RUN ./update_bundle.sh
+RUN STAGE_REPOS=true ./update_bundle.sh
 
 RUN rm /manifests/keda.*.clusterserviceversion.yaml
 

--- a/bundle-hack/regen-fbc-catalog.sh
+++ b/bundle-hack/regen-fbc-catalog.sh
@@ -23,33 +23,19 @@ for CATALOG_VERSION in catalogs/*; do
 
     if [ "$CATALOG_VERSION" == "catalogs/fbc" ]; then
         echo "rewriting prod images for $CATALOG_VERSION"
-        sed -i "s|$APP_PREFIX/keda-adapter|$PROD_PREFIX/keda-adapter-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/keda-operator|$PROD_PREFIX/keda-operator-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/keda-webhooks|$PROD_PREFIX/keda-webhooks-$OSVER|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator-bundle|$PROD_PREFIX/custom-metrics-autoscaler-operator-bundle|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator|$PROD_PREFIX/custom-metrics-autoscaler-operator-$OSVER|g" $CATALOG_OUTPUT
     elif [ "$CATALOG_VERSION" == "catalogs/fbc-stage" ]; then
         echo "rewriting stage images for $CATALOG_VERSION"
-        sed -i "s|$APP_PREFIX/keda-adapter|$STAGE_PREFIX/keda-adapter-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/keda-operator|$STAGE_PREFIX/keda-operator-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/keda-webhooks|$STAGE_PREFIX/keda-webhooks-$OSVER|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator-bundle|$STAGE_PREFIX/custom-metrics-autoscaler-operator-bundle|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator|$STAGE_PREFIX/custom-metrics-autoscaler-operator-$OSVER|g" $CATALOG_OUTPUT
-    # TODO(jkyros): I cut a special release for a customer by pushing the pipeline to my personal quay. I really don't like these copy-paste blocks
-    # but I don't have time right now to cook something good, and this is at least very straightforward, so this is what we get :)
+    # TODO(jkyros): I cut a special release for a customer by pushing the pipeline to my personal quay, we should think about how we want to do pre-release
+    # stuff for the future
     elif [ "$CATALOG_VERSION" == "catalogs/fbc-jkyros-quay" ]; then
       JKYROS_PREFIX="quay.io/jkyros"
       echo "rewriting quay images for $CATALOG_VERSION"
-        sed -i "s|$APP_PREFIX/keda-adapter|$JKYROS_PREFIX/keda-adapter-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/keda-operator|$JKYROS_PREFIX/keda-operator-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/keda-webhooks|$JKYROS_PREFIX/keda-webhooks-$OSVER|g" $CATALOG_OUTPUT
         # TODO(jkyros): This one is different because we need to build a different bundle image for a different target, and apparently the new
         # imagerepositories created with new components aren't nested under the application name anymore, so the path for this new bundle is different
         sed -i "s|quay.io/redhat-user-workloads/cma-podauto-tenant/custom-metrics-autoscaler-operator-bundle-jkyros-quay|$JKYROS_PREFIX/custom-metrics-autoscaler-konflux-operator-bundle|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator|$JKYROS_PREFIX/custom-metrics-autoscaler-operator-$OSVER|g" $CATALOG_OUTPUT
     fi
-
-
     # This is for all the old brew builds if we keep them in our catalog:
     sed -i 's|brew.registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler|registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler|g' $CATALOG_OUTPUT
 done

--- a/bundle-hack/regen-fbc-catalog.sh
+++ b/bundle-hack/regen-fbc-catalog.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 # TODO(jkyros): I used a template to generate the actual catalog, this script needs to be better/different but
 # opm interrogates all the bundles in the template, snarfs out their details, and then renders a final catalog based on
-# those details, so we can't the catalog generation itself as part of a hermetic build (it uses the network to look up the images)
+# those details, so we can't do the catalog generation itself as part of a hermetic build (it uses the network to look up the images)
 for CATALOG_VERSION in catalogs/*; do
     echo "found catalog $CATALOG_VERSION"
     CATALOG_OUTPUT=${CATALOG_VERSION}/catalog/custom-metrics-autoscaler-operator/catalog.yaml
@@ -16,7 +16,8 @@ for CATALOG_VERSION in catalogs/*; do
     OSVER="rhel9"
     APP_PREFIX="quay.io/redhat-user-workloads/cma-podauto-tenant/custom-metrics-autoscaler-operator"
     PROD_PREFIX="registry.redhat.io/custom-metrics-autoscaler"
-    # TODO(jkyros): originally I was referencing these straight out of stage, but
+    # TODO(jkyros): originally I was referencing these straight out of stage, but the "proper" way now is to
+    # is an ICSP to redirect to stage rather than reference stage directly
     #STAGE_PREFIX="registry.stage.redhat.io/custom-metrics-autoscaler"
     STAGE_PREFIX=$PROD_PREFIX
 
@@ -25,14 +26,14 @@ for CATALOG_VERSION in catalogs/*; do
         sed -i "s|$APP_PREFIX/keda-adapter|$PROD_PREFIX/keda-adapter-$OSVER|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/keda-operator|$PROD_PREFIX/keda-operator-$OSVER|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/keda-webhooks|$PROD_PREFIX/keda-webhooks-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator-bundle|$PROD_PREFIX/custom-metrics-autoscaler-konflux-operator-bundle|g" $CATALOG_OUTPUT
+        sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator-bundle|$PROD_PREFIX/custom-metrics-autoscaler-operator-bundle|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator|$PROD_PREFIX/custom-metrics-autoscaler-operator-$OSVER|g" $CATALOG_OUTPUT
     elif [ "$CATALOG_VERSION" == "catalogs/fbc-stage" ]; then
         echo "rewriting stage images for $CATALOG_VERSION"
         sed -i "s|$APP_PREFIX/keda-adapter|$STAGE_PREFIX/keda-adapter-$OSVER|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/keda-operator|$STAGE_PREFIX/keda-operator-$OSVER|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/keda-webhooks|$STAGE_PREFIX/keda-webhooks-$OSVER|g" $CATALOG_OUTPUT
-        sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator-bundle|$STAGE_PREFIX/custom-metrics-autoscaler-konflux-operator-bundle|g" $CATALOG_OUTPUT
+        sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator-bundle|$STAGE_PREFIX/custom-metrics-autoscaler-operator-bundle|g" $CATALOG_OUTPUT
         sed -i "s|$APP_PREFIX/custom-metrics-autoscaler-operator|$STAGE_PREFIX/custom-metrics-autoscaler-operator-$OSVER|g" $CATALOG_OUTPUT
     # TODO(jkyros): I cut a special release for a customer by pushing the pipeline to my personal quay. I really don't like these copy-paste blocks
     # but I don't have time right now to cook something good, and this is at least very straightforward, so this is what we get :)

--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -24,20 +24,29 @@ export KEDA_ADAPTER_PULLSPEC=$(<"imagerefs/keda-adapter.pullspec")
 [[ -z "$KEDA_ADAPTER_PULLSPEC" ]] && { echo "keda adapter pullspec is empty"; exit 1;}
 
 
-   # TODO(jkyros): we probably need multiple dockerfiles with different targets that feed an arg into this script, e.g. "push to stage", "push to prod", "push to quay"
-   # TODO(jkyros): oh, also, for fun, apparently the stage policy forces you to use registry.redhat.io also, and the intent is that you use like an ICSP to
-   # re-map the images, and NOTHING TELLS YOU THAT ANYWHERE
-   echo "REWRITE REPOS IS $REWRITE_REPOS"
+# TODO(jkyros): we probably need multiple dockerfiles with different targets that feed an arg into this script, e.g. "push to stage", "push to prod", "push to quay"
+# TODO(jkyros): oh, also, for fun, apparently the stage policy wants you to use registry.redhat.io also, and the intent is that you use like an ICSP to
+# re-map the images, and NOTHING TELLS YOU THAT ANYWHERE.
+echo "REWRITE REPOS IS $REWRITE_REPOS"
+APP_PREFIX="quay.io/redhat-user-workloads/cma-podauto-tenant/custom-metrics-autoscaler-operator"
+PROD_PREFIX="registry.redhat.io/custom-metrics-autoscaler"
+STAGE_PREFIX="registry.stage.redhat.io/custom-metrics-autoscaler"
+REWRITE_PREFIX=$PROD_PREFIX
+OSVER="rhel9"
+if [ -n "$STAGE_REPOS" ]; then
+   REWRITE_PREFIX=$STAGE_PREFIX
+fi
+
 if [ -n "$REWRITE_REPOS" ]; then
    CMA_OPERATOR_PULLSPEC=$( echo $CMA_OPERATOR_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#$REWRITE_REPOS/#" )
    KEDA_OPERATOR_PULLSPEC=$( echo $KEDA_OPERATOR_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#$REWRITE_REPOS/#" )
    KEDA_WEBHOOK_PULLSPEC=$( echo $KEDA_WEBHOOK_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#$REWRITE_REPOS/#" )
    KEDA_ADAPTER_PULLSPEC=$( echo $KEDA_ADAPTER_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#$REWRITE_REPOS/#" )
 else
-   CMA_OPERATOR_PULLSPEC=$( echo $CMA_OPERATOR_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.redhat.io/#" )
-   KEDA_OPERATOR_PULLSPEC=$( echo $KEDA_OPERATOR_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.redhat.io/#" )
-   KEDA_WEBHOOK_PULLSPEC=$( echo $KEDA_WEBHOOK_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.redhat.io/#" )
-   KEDA_ADAPTER_PULLSPEC=$( echo $KEDA_ADAPTER_PULLSPEC | sed -e "s#quay.io/redhat-user-workloads/cma-podauto-tenant/#registry.redhat.io/#" )
+   CMA_OPERATOR_PULLSPEC=$( echo $CMA_OPERATOR_PULLSPEC | sed -e "s#$APP_PREFIX/custom-metrics-autoscaler-operator#$REWRITE_PREFIX/custom-metrics-autoscaler-operator-$OSVER#" )
+   KEDA_OPERATOR_PULLSPEC=$( echo $KEDA_OPERATOR_PULLSPEC | sed -e "s#$APP_PREFIX/keda-operator#$REWRITE_PREFIX/keda-operator-$OSVER#" )
+   KEDA_WEBHOOK_PULLSPEC=$( echo $KEDA_WEBHOOK_PULLSPEC | sed -e "s#$APP_PREFIX/keda-webhooks#$REWRITE_PREFIX/keda-webhooks-$OSVER#" )
+   KEDA_ADAPTER_PULLSPEC=$( echo $KEDA_ADAPTER_PULLSPEC | sed -e "s#$APP_PREFIX/keda-adapter#$REWRITE_PREFIX/keda-adapter-$OSVER#" )
 fi
 
 


### PR DESCRIPTION
Previously I had created a konflux-specific bundle repo so avoid colliding with CPaaS, but now that we've done our `fbc_opt_in` through pyxis, we can move over to using the actual one. 
