### PR TITLE
referencing stage in bundle fails contract

### DIFF
--- a/Dockerfile.cma-operator-bundle
+++ b/Dockerfile.cma-operator-bundle
@@ -23,7 +23,7 @@ COPY releaseNum /releaseNum
 
 # This is going to sort out the most recent one and put it in /manifests/ and /metadata/ so
 # the next stage can use it from there
-RUN STAGE_REPOS=true ./update_bundle.sh
+RUN ./update_bundle.sh
 
 RUN rm /manifests/keda.*.clusterserviceversion.yaml
 


### PR DESCRIPTION
Alright, what we're doing here is, we're going to: 
- Build the bundle referencing prod so we can pass the EC
- The catalog will fail to update because it can't snarf the images out of prod (they are only in stage) but I think maybe I can use registries.conf to get around that 