### PR TITLE
Enable hermetic builds and Cachi2 RPM prefetch

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
@@ -94,11 +94,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
@@ -92,11 +92,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -72,11 +72,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod","path": "custom-metrics-autoscaler-operator/"},{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod","path": "custom-metrics-autoscaler-operator/"},{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -73,11 +73,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -73,11 +73,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -72,11 +72,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -70,11 +70,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '[{"type": "gomod", "path": "kedacore-keda/"},{"type": "gomod", "path": "kedacore-keda/hack/tooldeps/"},{"type": "gomod", "path": "tools/mock/"},{"type": "gomod", "path": "tools/controller-tools/"},{"type": "rpm","path":"rpm-lockfiles/"}]'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/Dockerfile.cma-operator
+++ b/Dockerfile.cma-operator
@@ -50,7 +50,7 @@ RUN INSTALL_PKGS=" \
       rsync \
       tar \
       " && \
-    microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms install -y $INSTALL_PKGS && \
+    microdnf install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     microdnf clean all
 

--- a/Dockerfile.cma-operator-bundle
+++ b/Dockerfile.cma-operator-bundle
@@ -3,9 +3,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder-runner
 
-#TODO(jkyros): Entitlements are still wacky, so we have to disable the entitled channels here, too
-RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms install -y skopeo jq python3 python3-pip
-RUN pip3 install --upgrade pip && pip3 install ruamel.yaml==0.17.9
+RUN microdnf install -y skopeo jq python3 python3-ruamel-yaml
 
 # Use a new stage to enable caching of the package installations for local development
 FROM builder-runner as builder

--- a/Dockerfile.keda-adapter
+++ b/Dockerfile.keda-adapter
@@ -20,26 +20,7 @@ ARG TARGETARCH
 # The KEDA makefiles need this to get the right platform
 ENV ARCH=${TARGETARCH}
 
-# TODO(jkyros): entirlements are always a clown show for some reason, if you don't do this, you get
-# cert errors because it's looking at rhsm-host and not rhsm and won't find the cert
-RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
-
-# TODO(jkyros): pin this to cache when we are able
-# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
-# the channels do not match the targetarch names, so we have to translate before we entble it
-# TODO(jkyros): cachito env will favor activation keys if one is present, you can either use the activation
-# key or etc-pki-entitlement secret, but not both, so that's why I'm using activation keys here, because we have one
-RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
-    elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
-    elif [ ${ARCH} == "s390x" ]; then ARCH="s390x"; \
-    elif [ ${ARCH} == "ppc64le" ]; then ARCH="ppc64le"; \
-    fi; \
-    export SMDEV_CONTAINER_OFF=1 && \
-    subscription-manager register --org $(cat "/activation-key/orgid") --activationkey $(cat "/activation-key/activationkey") && \
-    subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH}-rpms && \
-    dnf install -y protobuf-compiler && \
-    subscription-manager unregister
-
+RUN dnf install -y protobuf-compiler
 
 # Get the sources in here
 COPY /kedacore-keda/ /src/
@@ -60,9 +41,7 @@ RUN LOCALBIN=/src/bin make adapter
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 WORKDIR /
-# TODO(jkyros): It will try to pull from the RHEL channels because of the entitlement secret, so we have to disable
-# all the repos (the RHEL ones) and then enable the ubi repos.
-RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms install -y tzdata
+RUN microdnf install -y tzdata
 COPY --from=builder /src/bin/keda-adapter /usr/bin/
 RUN ln -s /usr/bin/keda-adapter /keda-adapter
 

--- a/Dockerfile.keda-operator
+++ b/Dockerfile.keda-operator
@@ -20,28 +20,7 @@ ARG TARGETARCH
 # The KEDA makefiles need this to get the right platform
 ENV ARCH=${TARGETARCH}
 
-# John added this
-
-# TODO(jkyros): entirlements are always a clown show for some reason, if you don't do this, you get
-# cert errors because it's looking at rhsm-host and not rhsm and won't find the cert
-RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
-
-# TODO(jkyros): pin this to cache when we are able
-# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
-# the channels do not match the targetarch names, so we have to translate before we entble it
-# TODO(jkyros): cachito env will favor activation keys if one is present, you can either use the activation
-# key or etc-pki-entitlement secret, but not both, so that's why I'm using activation keys here, because we have one
-RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
-    elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
-    elif [ ${ARCH} == "s390x" ]; then ARCH="s390x"; \
-    elif [ ${ARCH} == "ppc64le" ]; then ARCH="ppc64le"; \
-    fi; \
-    export SMDEV_CONTAINER_OFF=1 && \
-    subscription-manager register --org $(cat "/activation-key/orgid") --activationkey $(cat "/activation-key/activationkey") && \
-    subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH}-rpms && \
-    dnf install -y protobuf-compiler && \
-    subscription-manager unregister
-
+RUN dnf install -y protobuf-compiler
 
 # Get the sources in here
 COPY /kedacore-keda/ /src/
@@ -62,9 +41,7 @@ RUN LOCALBIN=/src/bin make manager
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 WORKDIR /
-# TODO(jkyros): It will try to pull from the RHEL channels because of the entitlement secret, so we have to disable
-# all the repos (the RHEL ones) and then enable the ubi repos.
-RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms install -y tzdata
+RUN microdnf install -y tzdata
 COPY --from=builder /src/bin/keda /usr/bin/
 RUN ln -s /usr/bin/keda /keda
 

--- a/Dockerfile.keda-webhooks
+++ b/Dockerfile.keda-webhooks
@@ -20,26 +20,7 @@ ARG TARGETARCH
 # The KEDA makefiles need this to get the right platform
 ENV ARCH=${TARGETARCH}
 
-# TODO(jkyros): entirlements are always a clown show for some reason, if you don't do this, you get
-# cert errors because it's looking at rhsm-host and not rhsm and won't find the cert
-RUN rm -rf /etc/rhsm-host && ln -s /etc/rhsm /etc/rhsm-host
-
-# TODO(jkyros): pin this to cache when we are able
-# protobuf-compiler lives in the codeready channel, which is an entitled channel, so we have to enable it, but
-# the channels do not match the targetarch names, so we have to translate before we entble it
-# TODO(jkyros): cachito env will favor activation keys if one is present, you can either use the activation
-# key or etc-pki-entitlement secret, but not both, so that's why I'm using activation keys here, because we have one
-RUN if [ ${ARCH} == "arm64" ] ; then ARCH="aarch64"; \
-    elif [ ${ARCH} == "amd64" ]; then ARCH="x86_64"; \
-    elif [ ${ARCH} == "s390x" ]; then ARCH="s390x"; \
-    elif [ ${ARCH} == "ppc64le" ]; then ARCH="ppc64le"; \
-    fi; \
-    export SMDEV_CONTAINER_OFF=1 && \
-    subscription-manager register --org $(cat "/activation-key/orgid") --activationkey $(cat "/activation-key/activationkey") && \
-    subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH}-rpms && \
-    dnf install -y protobuf-compiler && \
-    subscription-manager unregister
-
+RUN dnf install -y protobuf-compiler
 
 # Get the sources in here
 COPY /kedacore-keda/ /src/
@@ -60,9 +41,7 @@ RUN LOCALBIN=/src/bin make webhooks
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 WORKDIR /
-# TODO(jkyros): It will try to pull from the RHEL channels because of the entitlement secret, so we have to disable
-# all the repos (the RHEL ones) and then enable the ubi repos.
-RUN microdnf --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms install -y tzdata
+RUN microdnf install -y tzdata
 COPY --from=builder /src/bin/keda-admission-webhooks /usr/bin/
 RUN ln -s /usr/bin/keda-admission-webhooks /keda-admission-webhooks
 

--- a/rpm-lockfiles/rpms.lock.yaml
+++ b/rpm-lockfiles/rpms.lock.yaml
@@ -1,9 +1,217 @@
----
-lockfileVersion: 1
-lockfileVendor: redhat
 arches:
 - arch: aarch64
+  module_metadata: []
   packages:
+  - checksum: sha256:ef0ef043f1747dc597cf034f8543ac55987984d78fbebfb5ec7dd93ff563e649
+    evr: 2:1-96.el9_5
+    name: containers-common
+    repoid: ubi-9-appstream-rpms
+    size: 148030
+    sourcerpm: containers-common-1-96.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/containers-common-1-96.el9_5.aarch64.rpm
+  - checksum: sha256:a8d48e547151607ef6b4e2e83d7207c6a5de350a3ae68f0c9a0ee92745d36e1d
+    evr: 3.19-1.el9
+    name: criu
+    repoid: ubi-9-appstream-rpms
+    size: 560401
+    sourcerpm: criu-3.19-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/criu-3.19-1.el9.aarch64.rpm
+  - checksum: sha256:935aa34ce481fa755270cb502cad148c9b443d48a3994a481d65a23d21ac3844
+    evr: 3.19-1.el9
+    name: criu-libs
+    repoid: ubi-9-appstream-rpms
+    size: 32980
+    sourcerpm: criu-3.19-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/criu-libs-3.19-1.el9.aarch64.rpm
+  - checksum: sha256:ce8156849e756d7c0273fac1464db9ed31ea9bfc8d8a57a3d8c82f6e650102ac
+    evr: 1.16.1-1.el9
+    name: crun
+    repoid: ubi-9-appstream-rpms
+    size: 217572
+    sourcerpm: crun-1.16.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/crun-1.16.1-1.el9.aarch64.rpm
+  - checksum: sha256:aa95ce8a964df785e349e8ef3baf12eacde4695be51923fecfdbdc1b69b41933
+    evr: 1.14-1.el9
+    name: fuse-overlayfs
+    repoid: ubi-9-appstream-rpms
+    size: 66963
+    sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.aarch64.rpm
+  - checksum: sha256:2b911ff36ca332c9a5d0f2b2f088b51e9417d2085ec9c44967102f845825ad0f
+    evr: 3.10.2-9.el9
+    name: fuse3
+    repoid: ubi-9-appstream-rpms
+    size: 58189
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.aarch64.rpm
+  - checksum: sha256:5996291bc8dbb3d32f5d0ac693a4570dba5fe45631d4ca0552696285ff905370
+    evr: 3.10.2-9.el9
+    name: fuse3-libs
+    repoid: ubi-9-appstream-rpms
+    size: 92984
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.aarch64.rpm
+  - checksum: sha256:e21b572bcb332664bb342fe53d5ced4714ccd5008f2170049ef77fa2162183a0
+    evr: 1.6-15.el9
+    name: jq
+    repoid: ubi-9-appstream-rpms
+    size: 187128
+    sourcerpm: jq-1.6-15.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/j/jq-1.6-15.el9.aarch64.rpm
+  - checksum: sha256:543b0664c576f91ae8f5563f04c2cb3de65ff514d5ed658ac825aa4d98e860dd
+    evr: 1.2-7.el9
+    name: libnet
+    repoid: ubi-9-appstream-rpms
+    size: 62963
+    sourcerpm: libnet-1.2-7.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libnet-1.2-7.el9.aarch64.rpm
+  - checksum: sha256:12fa772c2e3905244fd6cc9971e2592c12a547ac3e4df66f5f0c6ef1e670067d
+    evr: 4.4.0-8.el9
+    name: libslirp
+    repoid: ubi-9-appstream-rpms
+    size: 70971
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.aarch64.rpm
+  - checksum: sha256:bc2305dad655ddb94f966158112efd6cefa6824d5aa2e80f63881f16cee74598
+    evr: 6.9.6-1.el9.5
+    name: oniguruma
+    repoid: ubi-9-appstream-rpms
+    size: 222582
+    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.aarch64.rpm
+  - checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
+    evr: 3.9.21-1.el9_5
+    name: python-unversioned-command
+    repoid: ubi-9-appstream-rpms
+    size: 10813
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
+  - checksum: sha256:2ff41d5bbfb5bf09378a499b56d9854e9389e3a8648897426d144f4b385f8730
+    evr: 21.3.1-1.el9
+    name: python3-pip
+    repoid: ubi-9-appstream-rpms
+    size: 2133958
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
+  - checksum: sha256:21d5c4e0f896661b4dd5dc777692a96263d7efed537b23ed505ee122084a2944
+    evr: 2:1.16.1-2.el9_5
+    name: skopeo
+    repoid: ubi-9-appstream-rpms
+    size: 8405099
+    sourcerpm: skopeo-1.16.1-2.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/skopeo-1.16.1-2.el9_5.aarch64.rpm
+  - checksum: sha256:7b6839b71e15f1289503eeaa2bb9cfd36573c04ea91a395f2283b17d254f7b75
+    evr: 1.3.1-1.el9
+    name: slirp4netns
+    repoid: ubi-9-appstream-rpms
+    size: 50451
+    sourcerpm: slirp4netns-1.3.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/slirp4netns-1.3.1-1.el9.aarch64.rpm
+  - checksum: sha256:a7f6bea0943bed2b2a9c49791bba0480086acad8ee6d2c24d18a1d82addfa12f
+    evr: 2.1.0-22.el9
+    name: yajl
+    repoid: ubi-9-appstream-rpms
+    size: 42214
+    sourcerpm: yajl-2.1.0-22.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/y/yajl-2.1.0-22.el9.aarch64.rpm
+  - checksum: sha256:74734affbd72263c90faef8ab20297ef5cd5bde7805956029e1f36c60a99e973
+    evr: 2.5.0-3.el9_5.1
+    name: expat
+    repoid: ubi-9-baseos-rpms
+    size: 116093
+    sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.aarch64.rpm
+  - checksum: sha256:ee202d37528745e6367791304c4f04af4a84bc9df2027234900186a8bff858f7
+    evr: 3.10.2-9.el9
+    name: fuse-common
+    repoid: ubi-9-baseos-rpms
+    size: 8718
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.aarch64.rpm
+  - checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
+    evr: 28-10.el9
+    name: kmod
+    repoid: ubi-9-baseos-rpms
+    size: 130824
+    sourcerpm: kmod-28-10.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
+  - checksum: sha256:7f6bd8eaf3817e1c31bb23d935820cce6db3538c22d9443fbce95854177f27f4
+    evr: 3.9.0-1.el9
+    name: libnl3
+    repoid: ubi-9-baseos-rpms
+    size: 354837
+    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.aarch64.rpm
+  - checksum: sha256:fc1d5e93483d166ca7f2acb50c04c181db2f3e7b89dba8edc6b1e5f2b0f10619
+    evr: 2.5.2-2.el9
+    name: libseccomp
+    repoid: ubi-9-baseos-rpms
+    size: 76024
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
+  - checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
+    evr: 1.3.3-13.el9
+    name: protobuf-c
+    repoid: ubi-9-baseos-rpms
+    size: 38582
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
+  - checksum: sha256:8f4c418c5857bee6cc18b91363f80065e15b7455554fbfe047c04b9d61509376
+    evr: 3.9.21-1.el9_5
+    name: python3
+    repoid: ubi-9-baseos-rpms
+    size: 30695
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.aarch64.rpm
+  - checksum: sha256:eecde68582784a716ed9370f9b23ef83483aed3d5adb4f0614386bd27bc22999
+    evr: 3.9.21-1.el9_5
+    name: python3-libs
+    repoid: ubi-9-baseos-rpms
+    size: 8474536
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.aarch64.rpm
+  - checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+    evr: 21.3.1-1.el9
+    name: python3-pip-wheel
+    repoid: ubi-9-baseos-rpms
+    size: 1193706
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+  - checksum: sha256:345f2e3dfa04ccdb65b4c4c9df1900f298acc3bd78dddff66f338fb7e62ccb85
+    evr: 53.0.0-13.el9
+    name: python3-setuptools
+    repoid: ubi-9-baseos-rpms
+    size: 969726
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-53.0.0-13.el9.noarch.rpm
+  - checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
+    evr: 53.0.0-13.el9
+    name: python3-setuptools-wheel
+    repoid: ubi-9-baseos-rpms
+    size: 480100
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
+  - checksum: sha256:cfe364a3eec12784b2397428ed21d7300a3cab826ec04208ff8e7a8539b73ccd
+    evr: 3.2.3-20.el9_5.1
+    name: rsync
+    repoid: ubi-9-baseos-rpms
+    size: 404320
+    sourcerpm: rsync-3.2.3-20.el9_5.1.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rsync-3.2.3-20.el9_5.1.aarch64.rpm
+  - checksum: sha256:44552dea889d350403c3074a33d7cb274b3f57553e47db998745df13f931b458
+    evr: 2:1.34-7.el9
+    name: tar
+    repoid: ubi-9-baseos-rpms
+    size: 900197
+    sourcerpm: tar-1.34-7.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-7.el9.aarch64.rpm
+  - checksum: sha256:b92f80510574427dec9f82d20a08248f1506ab0b5417b905a697569b615e9db2
+    evr: 2025a-1.el9
+    name: tzdata
+    repoid: ubi-9-baseos-rpms
+    size: 861118
+    sourcerpm: tzdata-2025a-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tzdata-2025a-1.el9.noarch.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/protobuf-3.14.0-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 962919
@@ -18,15 +226,233 @@ arches:
     name: protobuf-compiler
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rsync-3.2.3-19.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
-    size: 411313
-    checksum: sha256:ee29f2138b7f732ba3e552281c4bdf56c71112a17c19dd941135aa56c22cb2c8
-    name: rsync
-    evr: 3.2.3-19.el9
-    sourcerpm: rsync-3.2.3-19.el9.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-13.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 6492687
+    checksum: sha256:e1c0d70aaf82009015a6cb843a95f9643f18303d0d404e6611e42f7b46c0d7df
+    name: protobuf
+    evr: 3.14.0-13.el9
 - arch: x86_64
+  module_metadata: []
   packages:
+  - checksum: sha256:e8f54f5b0699c9fa69bd0a54f78f84ec8cf8c36fdd39a2a7ecc8c86e06fffb7d
+    evr: 2:1-96.el9_5
+    name: containers-common
+    repoid: ubi-9-appstream-rpms
+    size: 148067
+    sourcerpm: containers-common-1-96.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/containers-common-1-96.el9_5.x86_64.rpm
+  - checksum: sha256:823ac6aab1745521039d5aa4db2e843cb632854449d5b06420eb52825a985b59
+    evr: 3.19-1.el9
+    name: criu
+    repoid: ubi-9-appstream-rpms
+    size: 576009
+    sourcerpm: criu-3.19-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/criu-3.19-1.el9.x86_64.rpm
+  - checksum: sha256:bb821ddf9bd0321e0750d2fc5cadd5f531e67cafacf6d92512e714b31133a64d
+    evr: 3.19-1.el9
+    name: criu-libs
+    repoid: ubi-9-appstream-rpms
+    size: 33643
+    sourcerpm: criu-3.19-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/criu-libs-3.19-1.el9.x86_64.rpm
+  - checksum: sha256:799e1b2c4c898c72ccf45118bee379d1a2c427948be07efe547e43cbbda454a4
+    evr: 1.16.1-1.el9
+    name: crun
+    repoid: ubi-9-appstream-rpms
+    size: 231179
+    sourcerpm: crun-1.16.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.16.1-1.el9.x86_64.rpm
+  - checksum: sha256:884e4034c930e0305d2402da2bdc1eac5a91295da06e554b75c1c9a4529ddbc2
+    evr: 1.14-1.el9
+    name: fuse-overlayfs
+    repoid: ubi-9-appstream-rpms
+    size: 71022
+    sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.x86_64.rpm
+  - checksum: sha256:4674b4ee6150c8f8be01a028a471c209a6be7c0cf78e9450cf28fb01eaed9ea2
+    evr: 3.10.2-9.el9
+    name: fuse3
+    repoid: ubi-9-appstream-rpms
+    size: 58706
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.x86_64.rpm
+  - checksum: sha256:945e1d95edbce9c7dba52e9317d4564381efa5a1ba48d4bd49a58c85e47cd717
+    evr: 3.10.2-9.el9
+    name: fuse3-libs
+    repoid: ubi-9-appstream-rpms
+    size: 95573
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.x86_64.rpm
+  - checksum: sha256:d3157267cce88006c2ad3327ea7eb8983bea6f69327c157228b89814a3c473ae
+    evr: 1.6-15.el9
+    name: jq
+    repoid: ubi-9-appstream-rpms
+    size: 194271
+    sourcerpm: jq-1.6-15.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/j/jq-1.6-15.el9.x86_64.rpm
+  - checksum: sha256:738b9a7ab78c149487e349d90c384b59031d5763ba687a6b58a4f853671af86b
+    evr: 1.2-7.el9
+    name: libnet
+    repoid: ubi-9-appstream-rpms
+    size: 61278
+    sourcerpm: libnet-1.2-7.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libnet-1.2-7.el9.x86_64.rpm
+  - checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
+    evr: 4.4.0-8.el9
+    name: libslirp
+    repoid: ubi-9-appstream-rpms
+    size: 71992
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
+  - checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
+    evr: 4.4.18-3.el9
+    name: libxcrypt-compat
+    repoid: ubi-9-appstream-rpms
+    size: 93189
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
+  - checksum: sha256:6c884cc2216e5b4699ebd8cde27b39e99532520b367f645ed6cc660d081916dc
+    evr: 6.9.6-1.el9.5
+    name: oniguruma
+    repoid: ubi-9-appstream-rpms
+    size: 226331
+    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.x86_64.rpm
+  - checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
+    evr: 3.9.21-1.el9_5
+    name: python-unversioned-command
+    repoid: ubi-9-appstream-rpms
+    size: 10813
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
+  - checksum: sha256:2ff41d5bbfb5bf09378a499b56d9854e9389e3a8648897426d144f4b385f8730
+    evr: 21.3.1-1.el9
+    name: python3-pip
+    repoid: ubi-9-appstream-rpms
+    size: 2133958
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
+  - checksum: sha256:9ee81140efbcd9b024bfc40fb3572a17b64c81831184d90ac8babb52f4949bf7
+    evr: 2:1.16.1-2.el9_5
+    name: skopeo
+    repoid: ubi-9-appstream-rpms
+    size: 9199290
+    sourcerpm: skopeo-1.16.1-2.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/skopeo-1.16.1-2.el9_5.x86_64.rpm
+  - checksum: sha256:ddfeed233ab33a8eaf5dabf37e688398c9801f28822f411fa94e7b134cfd4ae6
+    evr: 1.3.1-1.el9
+    name: slirp4netns
+    repoid: ubi-9-appstream-rpms
+    size: 50412
+    sourcerpm: slirp4netns-1.3.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/slirp4netns-1.3.1-1.el9.x86_64.rpm
+  - checksum: sha256:e130574b0923861bfda720449d00cef5e2dfb13b1da94d5143354b3f2b10709c
+    evr: 2.1.0-22.el9
+    name: yajl
+    repoid: ubi-9-appstream-rpms
+    size: 42586
+    sourcerpm: yajl-2.1.0-22.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/y/yajl-2.1.0-22.el9.x86_64.rpm
+  - checksum: sha256:e9b4eb1c8a2ca7787a8ffea53b2a86533a1eb6aea72f05919c2748cd63dad32a
+    evr: 2.5.0-3.el9_5.1
+    name: expat
+    repoid: ubi-9-baseos-rpms
+    size: 121783
+    sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.x86_64.rpm
+  - checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
+    evr: 3.10.2-9.el9
+    name: fuse-common
+    repoid: ubi-9-baseos-rpms
+    size: 8750
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
+  - checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
+    evr: 28-10.el9
+    name: kmod
+    repoid: ubi-9-baseos-rpms
+    size: 132888
+    sourcerpm: kmod-28-10.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
+  - checksum: sha256:f436a96ba3433f501a7015bec2fa35ac05b52b776f0256b9c8cb3e6268086817
+    evr: 3.9.0-1.el9
+    name: libnl3
+    repoid: ubi-9-baseos-rpms
+    size: 367914
+    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.x86_64.rpm
+  - checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
+    evr: 2.5.2-2.el9
+    name: libseccomp
+    repoid: ubi-9-baseos-rpms
+    size: 76200
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
+  - checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
+    evr: 1.3.3-13.el9
+    name: protobuf-c
+    repoid: ubi-9-baseos-rpms
+    size: 38224
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
+  - checksum: sha256:2afbe12057e84e1fe11e82140624c6c71a2688b495499336ca50753a40974b14
+    evr: 3.9.21-1.el9_5
+    name: python3
+    repoid: ubi-9-baseos-rpms
+    size: 30760
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.x86_64.rpm
+  - checksum: sha256:bd3351b048dc50776a010bc38c7666ac1c335169c6d0b55c65cee47150520780
+    evr: 3.9.21-1.el9_5
+    name: python3-libs
+    repoid: ubi-9-baseos-rpms
+    size: 8490001
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.x86_64.rpm
+  - checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+    evr: 21.3.1-1.el9
+    name: python3-pip-wheel
+    repoid: ubi-9-baseos-rpms
+    size: 1193706
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+  - checksum: sha256:345f2e3dfa04ccdb65b4c4c9df1900f298acc3bd78dddff66f338fb7e62ccb85
+    evr: 53.0.0-13.el9
+    name: python3-setuptools
+    repoid: ubi-9-baseos-rpms
+    size: 969726
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-53.0.0-13.el9.noarch.rpm
+  - checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
+    evr: 53.0.0-13.el9
+    name: python3-setuptools-wheel
+    repoid: ubi-9-baseos-rpms
+    size: 480100
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
+  - checksum: sha256:cb9b3bbbba8f4f00414da7ce1b2ae12c8f3313a7ddb8b1162d60a690ca7e3a98
+    evr: 3.2.3-20.el9_5.1
+    name: rsync
+    repoid: ubi-9-baseos-rpms
+    size: 409799
+    sourcerpm: rsync-3.2.3-20.el9_5.1.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rsync-3.2.3-20.el9_5.1.x86_64.rpm
+  - checksum: sha256:17f2e592a2c04c050b690afeb9042e02521a0b5ee3288dad837463f4acf542c3
+    evr: 2:1.34-7.el9
+    name: tar
+    repoid: ubi-9-baseos-rpms
+    size: 910235
+    sourcerpm: tar-1.34-7.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-7.el9.x86_64.rpm
+  - checksum: sha256:b92f80510574427dec9f82d20a08248f1506ab0b5417b905a697569b615e9db2
+    evr: 2025a-1.el9
+    name: tzdata
+    repoid: ubi-9-baseos-rpms
+    size: 861118
+    sourcerpm: tzdata-2025a-1.el9.src.rpm
+    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tzdata-2025a-1.el9.noarch.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/protobuf-3.14.0-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1060262
@@ -41,13 +467,12 @@ arches:
     name: protobuf-compiler
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rsync-3.2.3-19.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
-    size: 411313
-    checksum: sha256:ee29f2138b7f732ba3e552281c4bdf56c71112a17c19dd941135aa56c22cb2c8
-    name: rsync
-    evr: 3.2.3-19.el9
-    sourcerpm: rsync-3.2.3-19.el9.src.rpm
-  source: []
-  module_metadata: []
-
+  source:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 6492687
+    checksum: sha256:e1c0d70aaf82009015a6cb843a95f9643f18303d0d404e6611e42f7b46c0d7df
+    name: protobuf
+    evr: 3.14.0-13.el9
+lockfileVendor: redhat
+lockfileVersion: 1

--- a/rpm-lockfiles/rpms.lock.yaml
+++ b/rpm-lockfiles/rpms.lock.yaml
@@ -1,217 +1,72 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
 arches:
 - arch: aarch64
-  module_metadata: []
   packages:
-  - checksum: sha256:ef0ef043f1747dc597cf034f8543ac55987984d78fbebfb5ec7dd93ff563e649
-    evr: 2:1-96.el9_5
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.17/os/Packages/c/containers-common-1-86.rhaos4.17.el9.aarch64.rpm
+    repoid: rhocp-4.17-for-rhel-9-aarch64-rpms
+    size: 100108
+    checksum: sha256:a5d02401de3d2050bba9d7daf3e0ed4616c3c4155b75b05227d4661e49680c14
     name: containers-common
-    repoid: ubi-9-appstream-rpms
-    size: 148030
-    sourcerpm: containers-common-1-96.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/containers-common-1-96.el9_5.aarch64.rpm
-  - checksum: sha256:a8d48e547151607ef6b4e2e83d7207c6a5de350a3ae68f0c9a0ee92745d36e1d
-    evr: 3.19-1.el9
-    name: criu
-    repoid: ubi-9-appstream-rpms
-    size: 560401
-    sourcerpm: criu-3.19-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/criu-3.19-1.el9.aarch64.rpm
-  - checksum: sha256:935aa34ce481fa755270cb502cad148c9b443d48a3994a481d65a23d21ac3844
-    evr: 3.19-1.el9
-    name: criu-libs
-    repoid: ubi-9-appstream-rpms
-    size: 32980
-    sourcerpm: criu-3.19-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/criu-libs-3.19-1.el9.aarch64.rpm
-  - checksum: sha256:ce8156849e756d7c0273fac1464db9ed31ea9bfc8d8a57a3d8c82f6e650102ac
-    evr: 1.16.1-1.el9
+    evr: 3:1-86.rhaos4.17.el9
+    sourcerpm: containers-common-1-86.rhaos4.17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.17/os/Packages/c/crun-1.19.1-1.rhaos4.17.el9.aarch64.rpm
+    repoid: rhocp-4.17-for-rhel-9-aarch64-rpms
+    size: 222924
+    checksum: sha256:35c30623ad95960122171de095d009d28d681c8e92b8fca72cf4b81dd5e99616
     name: crun
-    repoid: ubi-9-appstream-rpms
-    size: 217572
-    sourcerpm: crun-1.16.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/crun-1.16.1-1.el9.aarch64.rpm
-  - checksum: sha256:aa95ce8a964df785e349e8ef3baf12eacde4695be51923fecfdbdc1b69b41933
-    evr: 1.14-1.el9
-    name: fuse-overlayfs
-    repoid: ubi-9-appstream-rpms
+    evr: 1.19.1-1.rhaos4.17.el9
+    sourcerpm: crun-1.19.1-1.rhaos4.17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/c/criu-3.19-1.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 560401
+    checksum: sha256:a8d48e547151607ef6b4e2e83d7207c6a5de350a3ae68f0c9a0ee92745d36e1d
+    name: criu
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/c/criu-libs-3.19-1.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 32980
+    checksum: sha256:935aa34ce481fa755270cb502cad148c9b443d48a3994a481d65a23d21ac3844
+    name: criu-libs
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
     size: 66963
+    checksum: sha256:aa95ce8a964df785e349e8ef3baf12eacde4695be51923fecfdbdc1b69b41933
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
     sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.aarch64.rpm
-  - checksum: sha256:2b911ff36ca332c9a5d0f2b2f088b51e9417d2085ec9c44967102f845825ad0f
-    evr: 3.10.2-9.el9
-    name: fuse3
-    repoid: ubi-9-appstream-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
     size: 58189
-    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.aarch64.rpm
-  - checksum: sha256:5996291bc8dbb3d32f5d0ac693a4570dba5fe45631d4ca0552696285ff905370
+    checksum: sha256:2b911ff36ca332c9a5d0f2b2f088b51e9417d2085ec9c44967102f845825ad0f
+    name: fuse3
     evr: 3.10.2-9.el9
-    name: fuse3-libs
-    repoid: ubi-9-appstream-rpms
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
     size: 92984
-    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.aarch64.rpm
-  - checksum: sha256:e21b572bcb332664bb342fe53d5ced4714ccd5008f2170049ef77fa2162183a0
-    evr: 1.6-15.el9
-    name: jq
-    repoid: ubi-9-appstream-rpms
-    size: 187128
-    sourcerpm: jq-1.6-15.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/j/jq-1.6-15.el9.aarch64.rpm
-  - checksum: sha256:543b0664c576f91ae8f5563f04c2cb3de65ff514d5ed658ac825aa4d98e860dd
-    evr: 1.2-7.el9
-    name: libnet
-    repoid: ubi-9-appstream-rpms
-    size: 62963
-    sourcerpm: libnet-1.2-7.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libnet-1.2-7.el9.aarch64.rpm
-  - checksum: sha256:12fa772c2e3905244fd6cc9971e2592c12a547ac3e4df66f5f0c6ef1e670067d
-    evr: 4.4.0-8.el9
-    name: libslirp
-    repoid: ubi-9-appstream-rpms
-    size: 70971
-    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.aarch64.rpm
-  - checksum: sha256:bc2305dad655ddb94f966158112efd6cefa6824d5aa2e80f63881f16cee74598
-    evr: 6.9.6-1.el9.5
-    name: oniguruma
-    repoid: ubi-9-appstream-rpms
-    size: 222582
-    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.aarch64.rpm
-  - checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
-    evr: 3.9.21-1.el9_5
-    name: python-unversioned-command
-    repoid: ubi-9-appstream-rpms
-    size: 10813
-    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
-  - checksum: sha256:2ff41d5bbfb5bf09378a499b56d9854e9389e3a8648897426d144f4b385f8730
-    evr: 21.3.1-1.el9
-    name: python3-pip
-    repoid: ubi-9-appstream-rpms
-    size: 2133958
-    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
-  - checksum: sha256:21d5c4e0f896661b4dd5dc777692a96263d7efed537b23ed505ee122084a2944
-    evr: 2:1.16.1-2.el9_5
-    name: skopeo
-    repoid: ubi-9-appstream-rpms
-    size: 8405099
-    sourcerpm: skopeo-1.16.1-2.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/skopeo-1.16.1-2.el9_5.aarch64.rpm
-  - checksum: sha256:7b6839b71e15f1289503eeaa2bb9cfd36573c04ea91a395f2283b17d254f7b75
-    evr: 1.3.1-1.el9
-    name: slirp4netns
-    repoid: ubi-9-appstream-rpms
-    size: 50451
-    sourcerpm: slirp4netns-1.3.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/slirp4netns-1.3.1-1.el9.aarch64.rpm
-  - checksum: sha256:a7f6bea0943bed2b2a9c49791bba0480086acad8ee6d2c24d18a1d82addfa12f
-    evr: 2.1.0-22.el9
-    name: yajl
-    repoid: ubi-9-appstream-rpms
-    size: 42214
-    sourcerpm: yajl-2.1.0-22.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/y/yajl-2.1.0-22.el9.aarch64.rpm
-  - checksum: sha256:74734affbd72263c90faef8ab20297ef5cd5bde7805956029e1f36c60a99e973
-    evr: 2.5.0-3.el9_5.1
-    name: expat
-    repoid: ubi-9-baseos-rpms
-    size: 116093
-    sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.aarch64.rpm
-  - checksum: sha256:ee202d37528745e6367791304c4f04af4a84bc9df2027234900186a8bff858f7
+    checksum: sha256:5996291bc8dbb3d32f5d0ac693a4570dba5fe45631d4ca0552696285ff905370
+    name: fuse3-libs
     evr: 3.10.2-9.el9
-    name: fuse-common
-    repoid: ubi-9-baseos-rpms
-    size: 8718
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.aarch64.rpm
-  - checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
-    evr: 28-10.el9
-    name: kmod
-    repoid: ubi-9-baseos-rpms
-    size: 130824
-    sourcerpm: kmod-28-10.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
-  - checksum: sha256:7f6bd8eaf3817e1c31bb23d935820cce6db3538c22d9443fbce95854177f27f4
-    evr: 3.9.0-1.el9
-    name: libnl3
-    repoid: ubi-9-baseos-rpms
-    size: 354837
-    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.aarch64.rpm
-  - checksum: sha256:fc1d5e93483d166ca7f2acb50c04c181db2f3e7b89dba8edc6b1e5f2b0f10619
-    evr: 2.5.2-2.el9
-    name: libseccomp
-    repoid: ubi-9-baseos-rpms
-    size: 76024
-    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
-  - checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
-    evr: 1.3.3-13.el9
-    name: protobuf-c
-    repoid: ubi-9-baseos-rpms
-    size: 38582
-    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
-  - checksum: sha256:8f4c418c5857bee6cc18b91363f80065e15b7455554fbfe047c04b9d61509376
-    evr: 3.9.21-1.el9_5
-    name: python3
-    repoid: ubi-9-baseos-rpms
-    size: 30695
-    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.aarch64.rpm
-  - checksum: sha256:eecde68582784a716ed9370f9b23ef83483aed3d5adb4f0614386bd27bc22999
-    evr: 3.9.21-1.el9_5
-    name: python3-libs
-    repoid: ubi-9-baseos-rpms
-    size: 8474536
-    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.aarch64.rpm
-  - checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
-    evr: 21.3.1-1.el9
-    name: python3-pip-wheel
-    repoid: ubi-9-baseos-rpms
-    size: 1193706
-    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
-  - checksum: sha256:345f2e3dfa04ccdb65b4c4c9df1900f298acc3bd78dddff66f338fb7e62ccb85
-    evr: 53.0.0-13.el9
-    name: python3-setuptools
-    repoid: ubi-9-baseos-rpms
-    size: 969726
-    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-53.0.0-13.el9.noarch.rpm
-  - checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
-    evr: 53.0.0-13.el9
-    name: python3-setuptools-wheel
-    repoid: ubi-9-baseos-rpms
-    size: 480100
-    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
-  - checksum: sha256:cfe364a3eec12784b2397428ed21d7300a3cab826ec04208ff8e7a8539b73ccd
-    evr: 3.2.3-20.el9_5.1
-    name: rsync
-    repoid: ubi-9-baseos-rpms
-    size: 404320
-    sourcerpm: rsync-3.2.3-20.el9_5.1.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rsync-3.2.3-20.el9_5.1.aarch64.rpm
-  - checksum: sha256:44552dea889d350403c3074a33d7cb274b3f57553e47db998745df13f931b458
-    evr: 2:1.34-7.el9
-    name: tar
-    repoid: ubi-9-baseos-rpms
-    size: 900197
-    sourcerpm: tar-1.34-7.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-7.el9.aarch64.rpm
-  - checksum: sha256:b92f80510574427dec9f82d20a08248f1506ab0b5417b905a697569b615e9db2
-    evr: 2025a-1.el9
-    name: tzdata
-    repoid: ubi-9-baseos-rpms
-    size: 861118
-    sourcerpm: tzdata-2025a-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tzdata-2025a-1.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/l/libnet-1.2-7.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 62963
+    checksum: sha256:543b0664c576f91ae8f5563f04c2cb3de65ff514d5ed658ac825aa4d98e860dd
+    name: libnet
+    evr: 1.2-7.el9
+    sourcerpm: libnet-1.2-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 70971
+    checksum: sha256:12fa772c2e3905244fd6cc9971e2592c12a547ac3e4df66f5f0c6ef1e670067d
+    name: libslirp
+    evr: 4.4.0-8.el9
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/protobuf-3.14.0-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 962919
@@ -219,6 +74,160 @@ arches:
     name: protobuf
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 10813
+    checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
+    name: python-unversioned-command
+    evr: 3.9.21-1.el9_5
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python3-ruamel-yaml-0.16.6-7.el9.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 218591
+    checksum: sha256:23ad7563cf713a87aaefedc105c32ca72843801cad1024fb91af4db826a41425
+    name: python3-ruamel-yaml
+    evr: 0.16.6-7.el9.1
+    sourcerpm: python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python3-ruamel-yaml-clib-0.2.7-3.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 143199
+    checksum: sha256:aff2103881fadc44323b7cb8dddc2a5c0bc377ebc8eee0527ac9c435cccf38e8
+    name: python3-ruamel-yaml-clib
+    evr: 0.2.7-3.el9
+    sourcerpm: python-ruamel-yaml-clib-0.2.7-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/s/skopeo-1.16.1-2.el9_5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 8405099
+    checksum: sha256:21d5c4e0f896661b4dd5dc777692a96263d7efed537b23ed505ee122084a2944
+    name: skopeo
+    evr: 2:1.16.1-2.el9_5
+    sourcerpm: skopeo-1.16.1-2.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/s/slirp4netns-1.3.1-1.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 50451
+    checksum: sha256:7b6839b71e15f1289503eeaa2bb9cfd36573c04ea91a395f2283b17d254f7b75
+    name: slirp4netns
+    evr: 1.3.1-1.el9
+    sourcerpm: slirp4netns-1.3.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/y/yajl-2.1.0-22.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 42214
+    checksum: sha256:a7f6bea0943bed2b2a9c49791bba0480086acad8ee6d2c24d18a1d82addfa12f
+    name: yajl
+    evr: 2.1.0-22.el9
+    sourcerpm: yajl-2.1.0-22.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 116093
+    checksum: sha256:74734affbd72263c90faef8ab20297ef5cd5bde7805956029e1f36c60a99e973
+    name: expat
+    evr: 2.5.0-3.el9_5.1
+    sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 8718
+    checksum: sha256:ee202d37528745e6367791304c4f04af4a84bc9df2027234900186a8bff858f7
+    name: fuse-common
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/j/jq-1.6-17.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 188206
+    checksum: sha256:63cca45f59cf0a3e8534c000b2a47b27b0bba49b8c2db9f2746b00f52fda3a6a
+    name: jq
+    evr: 1.6-17.el9
+    sourcerpm: jq-1.6-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 130824
+    checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
+    name: kmod
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 354837
+    checksum: sha256:7f6bd8eaf3817e1c31bb23d935820cce6db3538c22d9443fbce95854177f27f4
+    name: libnl3
+    evr: 3.9.0-1.el9
+    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 76024
+    checksum: sha256:fc1d5e93483d166ca7f2acb50c04c181db2f3e7b89dba8edc6b1e5f2b0f10619
+    name: libseccomp
+    evr: 2.5.2-2.el9
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/o/oniguruma-6.9.6-1.el9.6.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 222676
+    checksum: sha256:a75ad34bc945249c352dc690055b429a04b405f0f62c6bc0f0962e501b104ef6
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+    sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 38582
+    checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 30695
+    checksum: sha256:8f4c418c5857bee6cc18b91363f80065e15b7455554fbfe047c04b9d61509376
+    name: python3
+    evr: 3.9.21-1.el9_5
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 8474536
+    checksum: sha256:eecde68582784a716ed9370f9b23ef83483aed3d5adb4f0614386bd27bc22999
+    name: python3-libs
+    evr: 3.9.21-1.el9_5
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 1193706
+    checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+    name: python3-pip-wheel
+    evr: 21.3.1-1.el9
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/python3-setuptools-53.0.0-13.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 969726
+    checksum: sha256:345f2e3dfa04ccdb65b4c4c9df1900f298acc3bd78dddff66f338fb7e62ccb85
+    name: python3-setuptools
+    evr: 53.0.0-13.el9
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 480100
+    checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
+    name: python3-setuptools-wheel
+    evr: 53.0.0-13.el9
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/r/rsync-3.2.3-20.el9_5.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 404320
+    checksum: sha256:cfe364a3eec12784b2397428ed21d7300a3cab826ec04208ff8e7a8539b73ccd
+    name: rsync
+    evr: 3.2.3-20.el9_5.1
+    sourcerpm: rsync-3.2.3-20.el9_5.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/t/tar-1.34-7.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 900197
+    checksum: sha256:44552dea889d350403c3074a33d7cb274b3f57553e47db998745df13f931b458
+    name: tar
+    evr: 2:1.34-7.el9
+    sourcerpm: tar-1.34-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/t/tzdata-2025a-1.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 861118
+    checksum: sha256:b92f80510574427dec9f82d20a08248f1506ab0b5417b905a697569b615e9db2
+    name: tzdata
+    evr: 2025a-1.el9
+    sourcerpm: tzdata-2025a-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/Packages/p/protobuf-compiler-3.14.0-13.el9.aarch64.rpm
     repoid: codeready-builder-for-rhel-9-aarch64-rpms
     size: 794569
@@ -227,232 +236,235 @@ arches:
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
   source:
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.17/source/SRPMS/Packages/c/containers-common-1-86.rhaos4.17.el9.src.rpm
+    repoid: rhocp-4.17-for-rhel-9-aarch64-source-rpms
+    size: 98351
+    checksum: sha256:b3573e49f15d886071e30051d7eefcc36012a12530f198ffea83b53d7fd26695
+    name: containers-common
+    evr: 3:1-86.rhaos4.17.el9
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.17/source/SRPMS/Packages/c/crun-1.19.1-1.rhaos4.17.el9.src.rpm
+    repoid: rhocp-4.17-for-rhel-9-aarch64-source-rpms
+    size: 1795539
+    checksum: sha256:588671ea1d0303f91889c11ec9c5a63d4f2173b37661e823318ff57edd613913
+    name: crun
+    evr: 1.19.1-1.rhaos4.17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/c/criu-3.19-1.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 1397103
+    checksum: sha256:e9d46b1c6c4ffa968a235504c57a721185ebc89bbc59e700589c908d0c1872f6
+    name: criu
+    evr: 3.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 114235
+    checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 611553
+    checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
+    name: libnet
+    evr: 1.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-13.el9.src.rpm
     repoid: rhel-9-for-aarch64-appstream-source-rpms
     size: 6492687
     checksum: sha256:e1c0d70aaf82009015a6cb843a95f9643f18303d0d404e6611e42f7b46c0d7df
     name: protobuf
     evr: 3.14.0-13.el9
-- arch: x86_64
-  module_metadata: []
-  packages:
-  - checksum: sha256:e8f54f5b0699c9fa69bd0a54f78f84ec8cf8c36fdd39a2a7ecc8c86e06fffb7d
-    evr: 2:1-96.el9_5
-    name: containers-common
-    repoid: ubi-9-appstream-rpms
-    size: 148067
-    sourcerpm: containers-common-1-96.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/containers-common-1-96.el9_5.x86_64.rpm
-  - checksum: sha256:823ac6aab1745521039d5aa4db2e843cb632854449d5b06420eb52825a985b59
-    evr: 3.19-1.el9
-    name: criu
-    repoid: ubi-9-appstream-rpms
-    size: 576009
-    sourcerpm: criu-3.19-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/criu-3.19-1.el9.x86_64.rpm
-  - checksum: sha256:bb821ddf9bd0321e0750d2fc5cadd5f531e67cafacf6d92512e714b31133a64d
-    evr: 3.19-1.el9
-    name: criu-libs
-    repoid: ubi-9-appstream-rpms
-    size: 33643
-    sourcerpm: criu-3.19-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/criu-libs-3.19-1.el9.x86_64.rpm
-  - checksum: sha256:799e1b2c4c898c72ccf45118bee379d1a2c427948be07efe547e43cbbda454a4
-    evr: 1.16.1-1.el9
-    name: crun
-    repoid: ubi-9-appstream-rpms
-    size: 231179
-    sourcerpm: crun-1.16.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.16.1-1.el9.x86_64.rpm
-  - checksum: sha256:884e4034c930e0305d2402da2bdc1eac5a91295da06e554b75c1c9a4529ddbc2
-    evr: 1.14-1.el9
-    name: fuse-overlayfs
-    repoid: ubi-9-appstream-rpms
-    size: 71022
-    sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.x86_64.rpm
-  - checksum: sha256:4674b4ee6150c8f8be01a028a471c209a6be7c0cf78e9450cf28fb01eaed9ea2
-    evr: 3.10.2-9.el9
-    name: fuse3
-    repoid: ubi-9-appstream-rpms
-    size: 58706
-    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.x86_64.rpm
-  - checksum: sha256:945e1d95edbce9c7dba52e9317d4564381efa5a1ba48d4bd49a58c85e47cd717
-    evr: 3.10.2-9.el9
-    name: fuse3-libs
-    repoid: ubi-9-appstream-rpms
-    size: 95573
-    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.x86_64.rpm
-  - checksum: sha256:d3157267cce88006c2ad3327ea7eb8983bea6f69327c157228b89814a3c473ae
-    evr: 1.6-15.el9
-    name: jq
-    repoid: ubi-9-appstream-rpms
-    size: 194271
-    sourcerpm: jq-1.6-15.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/j/jq-1.6-15.el9.x86_64.rpm
-  - checksum: sha256:738b9a7ab78c149487e349d90c384b59031d5763ba687a6b58a4f853671af86b
-    evr: 1.2-7.el9
-    name: libnet
-    repoid: ubi-9-appstream-rpms
-    size: 61278
-    sourcerpm: libnet-1.2-7.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libnet-1.2-7.el9.x86_64.rpm
-  - checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
-    evr: 4.4.0-8.el9
-    name: libslirp
-    repoid: ubi-9-appstream-rpms
-    size: 71992
-    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
-  - checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
-    evr: 4.4.18-3.el9
-    name: libxcrypt-compat
-    repoid: ubi-9-appstream-rpms
-    size: 93189
-    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
-  - checksum: sha256:6c884cc2216e5b4699ebd8cde27b39e99532520b367f645ed6cc660d081916dc
-    evr: 6.9.6-1.el9.5
-    name: oniguruma
-    repoid: ubi-9-appstream-rpms
-    size: 226331
-    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.x86_64.rpm
-  - checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
-    evr: 3.9.21-1.el9_5
-    name: python-unversioned-command
-    repoid: ubi-9-appstream-rpms
-    size: 10813
-    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
-  - checksum: sha256:2ff41d5bbfb5bf09378a499b56d9854e9389e3a8648897426d144f4b385f8730
-    evr: 21.3.1-1.el9
-    name: python3-pip
-    repoid: ubi-9-appstream-rpms
-    size: 2133958
-    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
-  - checksum: sha256:9ee81140efbcd9b024bfc40fb3572a17b64c81831184d90ac8babb52f4949bf7
-    evr: 2:1.16.1-2.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 241872
+    checksum: sha256:436bb919ee33c0d4d4ddf49564124315cfbb0915d226e3c6c5760b10d10ae473
+    name: python-ruamel-yaml
+    evr: 0.16.6-7.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-clib-0.2.7-3.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 217132
+    checksum: sha256:fafa739228fd439651ddd7fc336d34b3422df1c9bce9124f4faf27676edd13ff
+    name: python-ruamel-yaml-clib
+    evr: 0.2.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/s/skopeo-1.16.1-2.el9_5.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 10396055
+    checksum: sha256:fce400705e47b168c1dea350f6993614e163cc4dc380e84240285e30709d189f
     name: skopeo
-    repoid: ubi-9-appstream-rpms
-    size: 9199290
-    sourcerpm: skopeo-1.16.1-2.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/skopeo-1.16.1-2.el9_5.x86_64.rpm
-  - checksum: sha256:ddfeed233ab33a8eaf5dabf37e688398c9801f28822f411fa94e7b134cfd4ae6
-    evr: 1.3.1-1.el9
+    evr: 2:1.16.1-2.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 75832
+    checksum: sha256:e4cdf96b9b628650dfacd33375fb1ff3893f662a9ec2019ced2f8147fbd60d2a
     name: slirp4netns
-    repoid: ubi-9-appstream-rpms
-    size: 50412
-    sourcerpm: slirp4netns-1.3.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/slirp4netns-1.3.1-1.el9.x86_64.rpm
-  - checksum: sha256:e130574b0923861bfda720449d00cef5e2dfb13b1da94d5143354b3f2b10709c
-    evr: 2.1.0-22.el9
+    evr: 1.3.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/y/yajl-2.1.0-22.el9.src.rpm
+    repoid: rhel-9-for-aarch64-appstream-source-rpms
+    size: 101449
+    checksum: sha256:79e361ea2094e08f19c5a441a6e839b5424d1c4848d40cd3b3a5bcf1fb4b41f5
     name: yajl
-    repoid: ubi-9-appstream-rpms
-    size: 42586
-    sourcerpm: yajl-2.1.0-22.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/y/yajl-2.1.0-22.el9.x86_64.rpm
-  - checksum: sha256:e9b4eb1c8a2ca7787a8ffea53b2a86533a1eb6aea72f05919c2748cd63dad32a
-    evr: 2.5.0-3.el9_5.1
+    evr: 2.1.0-22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/e/expat-2.5.0-3.el9_5.1.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 8358505
+    checksum: sha256:8b3c398f73e7cfb93de1c34252c19ebd0efe4232e9b921bd01f11442b5dec8d5
     name: expat
-    repoid: ubi-9-baseos-rpms
-    size: 121783
-    sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.x86_64.rpm
-  - checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
+    evr: 2.5.0-3.el9_5.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
     evr: 3.10.2-9.el9
-    name: fuse-common
-    repoid: ubi-9-baseos-rpms
-    size: 8750
-    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
-  - checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
-    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 1503300
+    checksum: sha256:792ddc2a380e924ca859eeb01e83b93789af3dd10aca70697d5dfa32d13575a2
+    name: jq
+    evr: 1.6-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
     name: kmod
-    repoid: ubi-9-baseos-rpms
-    size: 132888
-    sourcerpm: kmod-28-10.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
-  - checksum: sha256:f436a96ba3433f501a7015bec2fa35ac05b52b776f0256b9c8cb3e6268086817
-    evr: 3.9.0-1.el9
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/l/libnl3-3.9.0-1.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 5013742
+    checksum: sha256:58c3697be0bc4eb3a6981402f10b6f5d00db52e1784f67079e73d170552c3b49
     name: libnl3
-    repoid: ubi-9-baseos-rpms
-    size: 367914
-    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.x86_64.rpm
-  - checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
-    evr: 2.5.2-2.el9
+    evr: 3.9.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 653169
+    checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
     name: libseccomp
-    repoid: ubi-9-baseos-rpms
-    size: 76200
-    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
-  - checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
-    evr: 1.3.3-13.el9
+    evr: 2.5.2-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
     name: protobuf-c
-    repoid: ubi-9-baseos-rpms
-    size: 38224
-    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
-  - checksum: sha256:2afbe12057e84e1fe11e82140624c6c71a2688b495499336ca50753a40974b14
-    evr: 3.9.21-1.el9_5
-    name: python3
-    repoid: ubi-9-baseos-rpms
-    size: 30760
-    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.x86_64.rpm
-  - checksum: sha256:bd3351b048dc50776a010bc38c7666ac1c335169c6d0b55c65cee47150520780
-    evr: 3.9.21-1.el9_5
-    name: python3-libs
-    repoid: ubi-9-baseos-rpms
-    size: 8490001
-    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.x86_64.rpm
-  - checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/p/python-pip-21.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 8984717
+    checksum: sha256:cb9e0cca3bd8dc24798cf1fb333d574774ce8288598331d44994d768f33648d3
+    name: python-pip
     evr: 21.3.1-1.el9
-    name: python3-pip-wheel
-    repoid: ubi-9-baseos-rpms
-    size: 1193706
-    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
-  - checksum: sha256:345f2e3dfa04ccdb65b4c4c9df1900f298acc3bd78dddff66f338fb7e62ccb85
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/p/python-setuptools-53.0.0-13.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 2081089
+    checksum: sha256:45c590d9b7665158618dcb0727fcadf0b72879920db69986fc2035550892a511
+    name: python-setuptools
     evr: 53.0.0-13.el9
-    name: python3-setuptools
-    repoid: ubi-9-baseos-rpms
-    size: 969726
-    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-53.0.0-13.el9.noarch.rpm
-  - checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
-    evr: 53.0.0-13.el9
-    name: python3-setuptools-wheel
-    repoid: ubi-9-baseos-rpms
-    size: 480100
-    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
-  - checksum: sha256:cb9b3bbbba8f4f00414da7ce1b2ae12c8f3313a7ddb8b1162d60a690ca7e3a98
-    evr: 3.2.3-20.el9_5.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/p/python3.9-3.9.21-1.el9_5.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 20273210
+    checksum: sha256:ef60fdf847c03312ab61602eb4c4aeac5f04bcc07b7a94178e71d4f5916b8345
+    name: python3.9
+    evr: 3.9.21-1.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/r/rsync-3.2.3-20.el9_5.1.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 1278074
+    checksum: sha256:4f42723607753b0009f4075f42a7a6d4d5090c253c3127774b249eda524c4045
     name: rsync
-    repoid: ubi-9-baseos-rpms
-    size: 409799
-    sourcerpm: rsync-3.2.3-20.el9_5.1.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rsync-3.2.3-20.el9_5.1.x86_64.rpm
-  - checksum: sha256:17f2e592a2c04c050b690afeb9042e02521a0b5ee3288dad837463f4acf542c3
-    evr: 2:1.34-7.el9
+    evr: 3.2.3-20.el9_5.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 2261512
+    checksum: sha256:d002c400d29e7305fe8a982ab6b9f49ee7a8780e4574b86fc0c5b3d5510ecb22
     name: tar
-    repoid: ubi-9-baseos-rpms
-    size: 910235
-    sourcerpm: tar-1.34-7.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-7.el9.x86_64.rpm
-  - checksum: sha256:b92f80510574427dec9f82d20a08248f1506ab0b5417b905a697569b615e9db2
-    evr: 2025a-1.el9
+    evr: 2:1.34-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/t/tzdata-2025a-1.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 902344
+    checksum: sha256:647a864eb614b9dc8b7d9f58a5e30e9cf38ccf8df8d03551b6507673a81488bd
     name: tzdata
-    repoid: ubi-9-baseos-rpms
-    size: 861118
-    sourcerpm: tzdata-2025a-1.el9.src.rpm
-    url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tzdata-2025a-1.el9.noarch.rpm
+    evr: 2025a-1.el9
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.17/os/Packages/c/containers-common-1-86.rhaos4.17.el9.x86_64.rpm
+    repoid: rhocp-4.17-for-rhel-9-x86_64-rpms
+    size: 100142
+    checksum: sha256:866dfb7c7f1568df98698015c70a7a7872e66a6f1a78aa0f448e57a9caa41429
+    name: containers-common
+    evr: 3:1-86.rhaos4.17.el9
+    sourcerpm: containers-common-1-86.rhaos4.17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.17/os/Packages/c/crun-1.19.1-1.rhaos4.17.el9.x86_64.rpm
+    repoid: rhocp-4.17-for-rhel-9-x86_64-rpms
+    size: 237814
+    checksum: sha256:483f465d575597d8e18c6bc122da15f946742b0ffab26fe604df2e246b37a7bf
+    name: crun
+    evr: 1.19.1-1.rhaos4.17.el9
+    sourcerpm: crun-1.19.1-1.rhaos4.17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/criu-3.19-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 576009
+    checksum: sha256:823ac6aab1745521039d5aa4db2e843cb632854449d5b06420eb52825a985b59
+    name: criu
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/criu-libs-3.19-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 33643
+    checksum: sha256:bb821ddf9bd0321e0750d2fc5cadd5f531e67cafacf6d92512e714b31133a64d
+    name: criu-libs
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 71022
+    checksum: sha256:884e4034c930e0305d2402da2bdc1eac5a91295da06e554b75c1c9a4529ddbc2
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+    sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 58706
+    checksum: sha256:4674b4ee6150c8f8be01a028a471c209a6be7c0cf78e9450cf28fb01eaed9ea2
+    name: fuse3
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 95573
+    checksum: sha256:945e1d95edbce9c7dba52e9317d4564381efa5a1ba48d4bd49a58c85e47cd717
+    name: fuse3-libs
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libnet-1.2-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 61278
+    checksum: sha256:738b9a7ab78c149487e349d90c384b59031d5763ba687a6b58a4f853671af86b
+    name: libnet
+    evr: 1.2-7.el9
+    sourcerpm: libnet-1.2-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 71992
+    checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
+    name: libslirp
+    evr: 4.4.0-8.el9
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 93189
+    checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
+    name: libxcrypt-compat
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/protobuf-3.14.0-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1060262
@@ -460,6 +472,160 @@ arches:
     name: protobuf
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 10813
+    checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
+    name: python-unversioned-command
+    evr: 3.9.21-1.el9_5
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-ruamel-yaml-0.16.6-7.el9.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 218621
+    checksum: sha256:edfa4be465a7ce774309cf67c85bd1a2f42fb9b5fe2508ccf681605c2ff21ee9
+    name: python3-ruamel-yaml
+    evr: 0.16.6-7.el9.1
+    sourcerpm: python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-ruamel-yaml-clib-0.2.7-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 151468
+    checksum: sha256:e7c146794a3e4ea343c32e68a3071ba72c941624f6340ede8bba60ff09d00851
+    name: python3-ruamel-yaml-clib
+    evr: 0.2.7-3.el9
+    sourcerpm: python-ruamel-yaml-clib-0.2.7-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/skopeo-1.16.1-2.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 9199290
+    checksum: sha256:9ee81140efbcd9b024bfc40fb3572a17b64c81831184d90ac8babb52f4949bf7
+    name: skopeo
+    evr: 2:1.16.1-2.el9_5
+    sourcerpm: skopeo-1.16.1-2.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/slirp4netns-1.3.1-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 50412
+    checksum: sha256:ddfeed233ab33a8eaf5dabf37e688398c9801f28822f411fa94e7b134cfd4ae6
+    name: slirp4netns
+    evr: 1.3.1-1.el9
+    sourcerpm: slirp4netns-1.3.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/y/yajl-2.1.0-22.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 42586
+    checksum: sha256:e130574b0923861bfda720449d00cef5e2dfb13b1da94d5143354b3f2b10709c
+    name: yajl
+    evr: 2.1.0-22.el9
+    sourcerpm: yajl-2.1.0-22.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 121783
+    checksum: sha256:e9b4eb1c8a2ca7787a8ffea53b2a86533a1eb6aea72f05919c2748cd63dad32a
+    name: expat
+    evr: 2.5.0-3.el9_5.1
+    sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 8750
+    checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
+    name: fuse-common
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jq-1.6-17.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 194646
+    checksum: sha256:9e996fbd48660f2815b29c88e1fd3b2ac5359eafb811f6208c6c4814ffb11e5b
+    name: jq
+    evr: 1.6-17.el9
+    sourcerpm: jq-1.6-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 132888
+    checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
+    name: kmod
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 367914
+    checksum: sha256:f436a96ba3433f501a7015bec2fa35ac05b52b776f0256b9c8cb3e6268086817
+    name: libnl3
+    evr: 3.9.0-1.el9
+    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 76200
+    checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
+    name: libseccomp
+    evr: 2.5.2-2.el9
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/oniguruma-6.9.6-1.el9.6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 226451
+    checksum: sha256:a532fc644b41ead28ac07fb4217e2ceb9cdd5fdaadc13e9a02b7be3ee703bf85
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+    sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38224
+    checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 30760
+    checksum: sha256:2afbe12057e84e1fe11e82140624c6c71a2688b495499336ca50753a40974b14
+    name: python3
+    evr: 3.9.21-1.el9_5
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 8490001
+    checksum: sha256:bd3351b048dc50776a010bc38c7666ac1c335169c6d0b55c65cee47150520780
+    name: python3-libs
+    evr: 3.9.21-1.el9_5
+    sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1193706
+    checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+    name: python3-pip-wheel
+    evr: 21.3.1-1.el9
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-setuptools-53.0.0-13.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 969726
+    checksum: sha256:345f2e3dfa04ccdb65b4c4c9df1900f298acc3bd78dddff66f338fb7e62ccb85
+    name: python3-setuptools
+    evr: 53.0.0-13.el9
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 480100
+    checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
+    name: python3-setuptools-wheel
+    evr: 53.0.0-13.el9
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rsync-3.2.3-20.el9_5.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 409799
+    checksum: sha256:cb9b3bbbba8f4f00414da7ce1b2ae12c8f3313a7ddb8b1162d60a690ca7e3a98
+    name: rsync
+    evr: 3.2.3-20.el9_5.1
+    sourcerpm: rsync-3.2.3-20.el9_5.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tar-1.34-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 910235
+    checksum: sha256:17f2e592a2c04c050b690afeb9042e02521a0b5ee3288dad837463f4acf542c3
+    name: tar
+    evr: 2:1.34-7.el9
+    sourcerpm: tar-1.34-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tzdata-2025a-1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 861118
+    checksum: sha256:b92f80510574427dec9f82d20a08248f1506ab0b5417b905a697569b615e9db2
+    name: tzdata
+    evr: 2025a-1.el9
+    sourcerpm: tzdata-2025a-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/Packages/p/protobuf-compiler-3.14.0-13.el9.x86_64.rpm
     repoid: codeready-builder-for-rhel-9-x86_64-rpms
     size: 886661
@@ -468,11 +634,166 @@ arches:
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
   source:
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.17/source/SRPMS/Packages/c/containers-common-1-86.rhaos4.17.el9.src.rpm
+    repoid: rhocp-4.17-for-rhel-9-x86_64-source-rpms
+    size: 98351
+    checksum: sha256:b3573e49f15d886071e30051d7eefcc36012a12530f198ffea83b53d7fd26695
+    name: containers-common
+    evr: 3:1-86.rhaos4.17.el9
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.17/source/SRPMS/Packages/c/crun-1.19.1-1.rhaos4.17.el9.src.rpm
+    repoid: rhocp-4.17-for-rhel-9-x86_64-source-rpms
+    size: 1795539
+    checksum: sha256:588671ea1d0303f91889c11ec9c5a63d4f2173b37661e823318ff57edd613913
+    name: crun
+    evr: 1.19.1-1.rhaos4.17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/criu-3.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1397103
+    checksum: sha256:e9d46b1c6c4ffa968a235504c57a721185ebc89bbc59e700589c908d0c1872f6
+    name: criu
+    evr: 3.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 114235
+    checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 611553
+    checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
+    name: libnet
+    evr: 1.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-13.el9.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 6492687
     checksum: sha256:e1c0d70aaf82009015a6cb843a95f9643f18303d0d404e6611e42f7b46c0d7df
     name: protobuf
     evr: 3.14.0-13.el9
-lockfileVendor: redhat
-lockfileVersion: 1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 241872
+    checksum: sha256:436bb919ee33c0d4d4ddf49564124315cfbb0915d226e3c6c5760b10d10ae473
+    name: python-ruamel-yaml
+    evr: 0.16.6-7.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-clib-0.2.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 217132
+    checksum: sha256:fafa739228fd439651ddd7fc336d34b3422df1c9bce9124f4faf27676edd13ff
+    name: python-ruamel-yaml-clib
+    evr: 0.2.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/skopeo-1.16.1-2.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10396055
+    checksum: sha256:fce400705e47b168c1dea350f6993614e163cc4dc380e84240285e30709d189f
+    name: skopeo
+    evr: 2:1.16.1-2.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 75832
+    checksum: sha256:e4cdf96b9b628650dfacd33375fb1ff3893f662a9ec2019ced2f8147fbd60d2a
+    name: slirp4netns
+    evr: 1.3.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/y/yajl-2.1.0-22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 101449
+    checksum: sha256:79e361ea2094e08f19c5a441a6e839b5424d1c4848d40cd3b3a5bcf1fb4b41f5
+    name: yajl
+    evr: 2.1.0-22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/expat-2.5.0-3.el9_5.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8358505
+    checksum: sha256:8b3c398f73e7cfb93de1c34252c19ebd0efe4232e9b921bd01f11442b5dec8d5
+    name: expat
+    evr: 2.5.0-3.el9_5.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1503300
+    checksum: sha256:792ddc2a380e924ca859eeb01e83b93789af3dd10aca70697d5dfa32d13575a2
+    name: jq
+    evr: 1.6-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnl3-3.9.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5013742
+    checksum: sha256:58c3697be0bc4eb3a6981402f10b6f5d00db52e1784f67079e73d170552c3b49
+    name: libnl3
+    evr: 3.9.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 653169
+    checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
+    name: libseccomp
+    evr: 2.5.2-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543970
+    checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
+    name: libxcrypt
+    evr: 4.4.18-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/python-pip-21.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8984717
+    checksum: sha256:cb9e0cca3bd8dc24798cf1fb333d574774ce8288598331d44994d768f33648d3
+    name: python-pip
+    evr: 21.3.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/python-setuptools-53.0.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2081089
+    checksum: sha256:45c590d9b7665158618dcb0727fcadf0b72879920db69986fc2035550892a511
+    name: python-setuptools
+    evr: 53.0.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/python3.9-3.9.21-1.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 20273210
+    checksum: sha256:ef60fdf847c03312ab61602eb4c4aeac5f04bcc07b7a94178e71d4f5916b8345
+    name: python3.9
+    evr: 3.9.21-1.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rsync-3.2.3-20.el9_5.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1278074
+    checksum: sha256:4f42723607753b0009f4075f42a7a6d4d5090c253c3127774b249eda524c4045
+    name: rsync
+    evr: 3.2.3-20.el9_5.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2261512
+    checksum: sha256:d002c400d29e7305fe8a982ab6b9f49ee7a8780e4574b86fc0c5b3d5510ecb22
+    name: tar
+    evr: 2:1.34-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tzdata-2025a-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 902344
+    checksum: sha256:647a864eb614b9dc8b7d9f58a5e30e9cf38ccf8df8d03551b6507673a81488bd
+    name: tzdata
+    evr: 2025a-1.el9
+  module_metadata: []


### PR DESCRIPTION
Apparently https://issues.redhat.com/browse/STONEBLD-2618 is done now.
https://konflux.pages.redhat.com/docs/users/how-tos/configuring/activation-keys-subscription.html
    
* Pin protobuf-compiler RPM metadata for prefetch
* Semantic revert of "konflux: disable hermetic, it's not done yet"
      (8f61a0ca1cfa156aada1ed94e5e1ca653634fbe1)
* Semantic revert of "konflux: disable prefetch entirely until new version"
      (28d27e7c1f373ea55d7b7b14c1a21215267e9b98)
* Semantic revert of "konflux: remote RPMs from prefetch, doesn't work yet"
      (a787aaeb83f83505355d8f60b3a7f8ca95abe414)
* Pin protobuf-compiler RPM metadata for prefetch
* Enable hermetic builds for bundles
* Also, switch python3-ruamel-yaml install from pip to RPM
