### PR TITLE
Temporarily remove ecosystem-cert-preflight-checks test from bundle pipelines

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-pull-request.yaml
@@ -333,26 +333,28 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+#    It was configured to be skipped, which caused us to fail our EC checks. People on Slack said to disable/remove it for now
+#    https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1739212062777609
+#    - name: ecosystem-cert-preflight-checks
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: ecosystem-cert-preflight-checks
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-push.yaml
@@ -330,26 +330,28 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+#    It was configured to be skipped, which caused us to fail our EC checks. People on Slack said to disable/remove it for now
+#    https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1739212062777609
+#    - name: ecosystem-cert-preflight-checks
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: ecosystem-cert-preflight-checks
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
@@ -320,26 +320,28 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+#    It was configured to be skipped, which caused us to fail our EC checks. People on Slack said to disable/remove it for now
+#    https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1739212062777609
+#    - name: ecosystem-cert-preflight-checks
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: ecosystem-cert-preflight-checks
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
@@ -318,26 +318,28 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+#    It was configured to be skipped, which caused us to fail our EC checks. People on Slack said to disable/remove it for now
+#    https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1739212062777609
+#    - name: ecosystem-cert-preflight-checks
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-container.results.IMAGE_URL)
+#      runAfter:
+#      - build-container
+#      taskRef:
+#        params:
+#        - name: name
+#          value: ecosystem-cert-preflight-checks
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest


### PR DESCRIPTION
... since it doesn't do anything and it cause EC failures for a skipped
check