### PR TITLE
Revert "Manually install fix for CVE-2024-12797 until base image has it

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-pull-request.yaml".pathChanged() )
+      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-pull-request.yaml".pathChanged() || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/custom-metrics-autoscaler-operator.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-push.yaml".pathChanged() )
+      == "cma-konflux" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-push.yaml".pathChanged() || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux"  && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-pull-request.yaml".pathChanged() )
+      == "cma-konflux"  && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-pull-request.yaml".pathChanged() || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   creationTimestamp: null
   labels:

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/keda-adapter.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-push.yaml".pathChanged() )
+      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-push.yaml".pathChanged() || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux"  && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-pull-request.yaml".pathChanged())
+      == "cma-konflux"  && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-pull-request.yaml".pathChanged() || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   creationTimestamp: null
   labels:

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/keda-operator.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-push.yaml".pathChanged() )
+      == "cma-konflux" && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-push.yaml".pathChanged()  || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "cma-konflux" && ("kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-pull-request.yaml".pathChanged() )
+      == "cma-konflux" && ("kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-pull-request.yaml".pathChanged() || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/imagerefs/keda-webhooks.pullspec"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-push.yaml".pathChanged() )
+      == "cma-konflux" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-push.yaml".pathChanged()  || "rpm-lockfiles/rpms.lock.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/rpm-lockfiles/rpms.lock.yaml
+++ b/rpm-lockfiles/rpms.lock.yaml
@@ -158,20 +158,6 @@ arches:
     name: oniguruma
     evr: 6.9.6-1.el9.6
     sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 1398689
-    checksum: sha256:f914250a9ef52968e27af0f0e2520745df4443dc354367bec54dd06b4a2da60b
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 2085943
-    checksum: sha256:fb9062e4635959a929f278002c5ff1bf35323987538c71fa86442c980eab4a44
-    name: openssl-libs
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 38582
@@ -292,12 +278,6 @@ arches:
     checksum: sha256:e1c0d70aaf82009015a6cb843a95f9643f18303d0d404e6611e42f7b46c0d7df
     name: protobuf
     evr: 3.14.0-13.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
-    repoid: rhel-9-for-aarch64-appstream-source-rpms
-    size: 241872
-    checksum: sha256:436bb919ee33c0d4d4ddf49564124315cfbb0915d226e3c6c5760b10d10ae473
-    name: python-ruamel-yaml
-    evr: 0.16.6-7.el9.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-clib-0.2.7-3.el9.src.rpm
     repoid: rhel-9-for-aarch64-appstream-source-rpms
     size: 217132
@@ -364,12 +344,6 @@ arches:
     checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
     name: oniguruma
     evr: 6.9.6-1.el9.6
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
-    repoid: rhel-9-for-aarch64-baseos-source-rpms
-    size: 17985138
-    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
     repoid: rhel-9-for-aarch64-baseos-source-rpms
     size: 513224
@@ -412,6 +386,12 @@ arches:
     checksum: sha256:647a864eb614b9dc8b7d9f58a5e30e9cf38ccf8df8d03551b6507673a81488bd
     name: tzdata
     evr: 2025a-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/source/SRPMS/Packages/p/python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
+    repoid: codeready-builder-for-rhel-9-aarch64-source-rpms
+    size: 241872
+    checksum: sha256:436bb919ee33c0d4d4ddf49564124315cfbb0915d226e3c6c5760b10d10ae473
+    name: python-ruamel-yaml
+    evr: 0.16.6-7.el9.1
   module_metadata: []
 - arch: x86_64
   packages:
@@ -576,20 +556,6 @@ arches:
     name: oniguruma
     evr: 6.9.6-1.el9.6
     sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1420999
-    checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2218318
-    checksum: sha256:287d11706d44a53455ed8ac62faab4c4a0b8c0fa5e367adf122c7a76c6ddbbb8
-    name: openssl-libs
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38224
@@ -710,12 +676,6 @@ arches:
     checksum: sha256:e1c0d70aaf82009015a6cb843a95f9643f18303d0d404e6611e42f7b46c0d7df
     name: protobuf
     evr: 3.14.0-13.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
-    repoid: rhel-9-for-x86_64-appstream-source-rpms
-    size: 241872
-    checksum: sha256:436bb919ee33c0d4d4ddf49564124315cfbb0915d226e3c6c5760b10d10ae473
-    name: python-ruamel-yaml
-    evr: 0.16.6-7.el9.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python-ruamel-yaml-clib-0.2.7-3.el9.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 217132
@@ -788,12 +748,6 @@ arches:
     checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
     name: oniguruma
     evr: 6.9.6-1.el9.6
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
-    repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 17985138
-    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 513224
@@ -836,4 +790,10 @@ arches:
     checksum: sha256:647a864eb614b9dc8b7d9f58a5e30e9cf38ccf8df8d03551b6507673a81488bd
     name: tzdata
     evr: 2025a-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/source/SRPMS/Packages/p/python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-source-rpms
+    size: 241872
+    checksum: sha256:436bb919ee33c0d4d4ddf49564124315cfbb0915d226e3c6c5760b10d10ae473
+    name: python-ruamel-yaml
+    evr: 0.16.6-7.el9.1
   module_metadata: []


### PR DESCRIPTION
This is a semantic revert of 661942a3497f11de6fd093ea9be2b01586ca041b since an actual revert would have loads of conflicts. Removed openssl{,-libs} from the input and regenerated rpm-lockfiles/rpms.lock.yaml