### PR TITLE
Update to a fixed task-fbc-fips-check-oci-ta:0.1 task

### DIFF
--- a/.tekton/cma-fbc-stage-4-12-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-12-pull-request.yaml
@@ -297,7 +297,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-12-push.yaml
+++ b/.tekton/cma-fbc-stage-4-12-push.yaml
@@ -292,7 +292,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-13-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-13-pull-request.yaml
@@ -297,7 +297,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-13-push.yaml
+++ b/.tekton/cma-fbc-stage-4-13-push.yaml
@@ -292,7 +292,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-14-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-14-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-14-push.yaml
+++ b/.tekton/cma-fbc-stage-4-14-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-15-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-15-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-15-push.yaml
+++ b/.tekton/cma-fbc-stage-4-15-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-16-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-16-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-16-push.yaml
+++ b/.tekton/cma-fbc-stage-4-16-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-17-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-17-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-17-push.yaml
+++ b/.tekton/cma-fbc-stage-4-17-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-18-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-18-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-18-push.yaml
+++ b/.tekton/cma-fbc-stage-4-18-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-19-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-19-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-4-19-push.yaml
+++ b/.tekton/cma-fbc-stage-4-19-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-pull-request.yaml
@@ -282,7 +282,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cma-fbc-stage-push.yaml
+++ b/.tekton/cma-fbc-stage-push.yaml
@@ -280,7 +280,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml
@@ -298,7 +298,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-push.yaml
@@ -293,7 +293,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml
@@ -297,7 +297,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-push.yaml
@@ -292,7 +292,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml
@@ -299,7 +299,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-push.yaml
@@ -294,7 +294,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-pull-request.yaml
@@ -300,7 +300,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-push.yaml
@@ -300,7 +300,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:cb263beb7f4da0d76e01f1fe299f6ff724b78fdd65c4f1a3caedf5ecda2a64b2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -5,21 +5,21 @@ metadata:
   name: example-mirror-set
 spec:
   imageDigestMirrors:
-    - mirrors:
-      - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
-      source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
-    - mirrors:
-      - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-adapter-rhel9
-      source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-adapter-rhel9
-    - mirrors:
-      - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-admission-webhooks-rhel9
-      source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-admission-webhooks-rhel9
-    - mirrors:
-      - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
-      source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
-    - mirrors:
-      - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9-operator
-      source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9-operator
-    - mirrors:
-      - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9
-      source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-adapter-rhel9
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-adapter-rhel9
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-admission-webhooks-rhel9
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-admission-webhooks-rhel9
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-operator-bundle
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9-operator
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9-operator
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9


### PR DESCRIPTION
Now that https://github.com/konflux-ci/konflux-test/commit/9ecc95aea22cb2aad7a0a89dff5353c4073a1215 and https://github.com/konflux-ci/build-definitions/pull/1975 have merged, hopefully the check will start passing